### PR TITLE
Add native Windows support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+*.cmd text eol=crlf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
       - run: pnpm check
       - run: pnpm build
       - run: pnpm test
+        if: runner.os != 'Windows'
+      - run: pnpm test:windows
+        if: runner.os == 'Windows'
       - run: pnpm pack:check
       - run: pnpm pack:smoke
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
+          - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ Hive is built for people who already use CLI coding agents and want a tighter
 way to coordinate several of them without giving up each agent's native
 terminal workflow.
 
-> Public preview status: macOS and Linux are the Tier 1 targets. Windows is not
-> a supported target yet; use WSL/Linux for now.
+> Public preview status: macOS, Linux, and Windows are the Tier 1 targets.
 
 ## 60 Second Start
 
@@ -70,7 +69,7 @@ CLI before selecting it in Hive.
 | --- | --- | --- |
 | macOS | Tier 1 | Local development and release verification target. |
 | Linux | Tier 1 | CI verification target; folder picking expects `zenity` when using the native picker. |
-| Windows | Not supported yet | Folder picking and packaged `node-pty` behavior are not part of the public preview. Use WSL/Linux. |
+| Windows | Tier 1 | CI verification target; folder picking uses Windows PowerShell and the packaged internal `team.cmd`. |
 
 ## Safety Model
 
@@ -142,11 +141,17 @@ hive --port 4020
 **Native PTY install fails**
 
 Hive depends on `node-pty`, which ships native binaries. Use Node.js 22+, keep
-your package manager cache clean, and verify your platform is macOS or Linux.
+your package manager cache clean, and verify your platform is macOS, Linux, or
+Windows.
 
 **Folder picker does not open on Linux**
 
 Install `zenity`, or paste the workspace path manually.
+
+**Folder picker does not open on Windows**
+
+Verify Windows PowerShell is available as `powershell.exe`, or paste the
+workspace path manually.
 
 **Tasks file conflict banner appears**
 

--- a/bin/team.cmd
+++ b/bin/team.cmd
@@ -1,0 +1,2 @@
+@echo off
+node "%~dp0..\src\cli\team.js" %*

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "dev:all": "concurrently \"pnpm dev:runtime\" \"pnpm dev:web\"",
     "dev:runtime": "tsx src/cli/hive.ts --port 4010",
     "dev:web": "vite --config web/vite.config.ts",
-    "build": "pnpm clean && tsc -p tsconfig.build.json && mkdir -p dist/bin && cp bin/team dist/bin/team && chmod +x dist/bin/team && pnpm build:web",
+    "build": "pnpm clean && tsc -p tsconfig.build.json && node scripts/prepare-build-artifacts.mjs && pnpm build:web",
     "build:web": "vite build --config web/vite.config.ts",
     "check": "pnpm exec biome check .",
     "format": "pnpm exec biome format --write .",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "postinstall": "node scripts/fix-runtime-artifacts.mjs",
     "release:dry": "pnpm check && pnpm build && pnpm test && pnpm pack:check && pnpm pack:smoke",
     "test": "vitest run",
-    "test:windows": "vitest run tests/unit/agent-command-resolver.test.ts tests/unit/session-capture-multi-cli.test.ts tests/unit/claude-session-support.test.ts tests/unit/worker-name-generator.test.ts tests/server/fs-pick-folder.test.ts tests/server/fs-browse.test.ts tests/server/schema-version.test.ts tests/server/runtime-rehydration.test.ts tests/integration/package-tarball.test.ts tests/web/workspace-picker.test.tsx tests/web/confirm-dialog.test.tsx tests/web/toast.test.tsx --no-file-parallelism --maxWorkers=1 --testTimeout=30000 --hookTimeout=30000",
+    "test:windows": "vitest run tests/unit/agent-command-resolver.test.ts tests/unit/session-capture-multi-cli.test.ts tests/unit/claude-session-support.test.ts tests/unit/worker-name-generator.test.ts tests/server/fs-pick-folder.test.ts tests/server/fs-browse.test.ts tests/server/schema-version.test.ts tests/server/runtime-rehydration.test.ts tests/web/workspace-picker.test.tsx tests/web/confirm-dialog.test.tsx tests/web/toast.test.tsx --no-file-parallelism --maxWorkers=1 --testTimeout=30000 --hookTimeout=30000",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "postinstall": "node scripts/fix-runtime-artifacts.mjs",
     "release:dry": "pnpm check && pnpm build && pnpm test && pnpm pack:check && pnpm pack:smoke",
     "test": "vitest run",
-    "test:windows": "vitest run tests/unit/agent-command-resolver.test.ts tests/unit/session-capture-multi-cli.test.ts tests/unit/claude-session-support.test.ts tests/unit/worker-name-generator.test.ts tests/server/fs-pick-folder.test.ts tests/server/fs-browse.test.ts tests/server/schema-version.test.ts tests/server/runtime-rehydration.test.ts tests/integration/package-tarball.test.ts tests/web/workspace-picker.test.tsx tests/web/confirm-dialog.test.tsx tests/web/toast.test.tsx --no-file-parallelism --maxWorkers=1",
+    "test:windows": "vitest run tests/unit/agent-command-resolver.test.ts tests/unit/session-capture-multi-cli.test.ts tests/unit/claude-session-support.test.ts tests/unit/worker-name-generator.test.ts tests/server/fs-pick-folder.test.ts tests/server/fs-browse.test.ts tests/server/schema-version.test.ts tests/server/runtime-rehydration.test.ts tests/integration/package-tarball.test.ts tests/web/workspace-picker.test.tsx tests/web/confirm-dialog.test.tsx tests/web/toast.test.tsx --no-file-parallelism --maxWorkers=1 --testTimeout=30000 --hookTimeout=30000",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "postinstall": "node scripts/fix-runtime-artifacts.mjs",
     "release:dry": "pnpm check && pnpm build && pnpm test && pnpm pack:check && pnpm pack:smoke",
     "test": "vitest run",
+    "test:windows": "vitest run tests/unit/agent-command-resolver.test.ts tests/unit/session-capture-multi-cli.test.ts tests/unit/claude-session-support.test.ts tests/unit/worker-name-generator.test.ts tests/server/fs-pick-folder.test.ts tests/server/fs-browse.test.ts tests/server/schema-version.test.ts tests/server/runtime-rehydration.test.ts tests/integration/package-tarball.test.ts tests/web/workspace-picker.test.tsx tests/web/confirm-dialog.test.tsx tests/web/toast.test.tsx --no-file-parallelism --maxWorkers=1",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/scripts/fix-runtime-artifacts.mjs
+++ b/scripts/fix-runtime-artifacts.mjs
@@ -4,7 +4,9 @@ import { dirname, join } from 'node:path'
 
 const executablePaths = [
   'bin/team',
+  'bin/team.cmd',
   'dist/bin/team',
+  'dist/bin/team.cmd',
   'node_modules/.pnpm/node-pty@1.1.0/node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper',
 ]
 

--- a/scripts/pack-smoke.mjs
+++ b/scripts/pack-smoke.mjs
@@ -6,6 +6,8 @@ import { join, resolve } from 'node:path'
 const root = process.cwd()
 const tempDir = mkdtempSync(join(tmpdir(), 'hive-pack-smoke-'))
 let packedFile
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+const binLinkName = (name) => (process.platform === 'win32' ? `${name}.cmd` : name)
 
 const waitFor = async (predicate, timeoutMs = 5000) => {
   const deadline = Date.now() + timeoutMs
@@ -34,7 +36,7 @@ const stopChild = async (child) => {
 }
 
 try {
-  const packJson = execFileSync('npm', ['pack', '--json'], {
+  const packJson = execFileSync(npmCommand, ['pack', '--json'], {
     cwd: root,
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'inherit'],
@@ -42,18 +44,23 @@ try {
   const [packResult] = JSON.parse(packJson)
   packedFile = resolve(root, packResult.filename)
 
-  execFileSync('npm', ['install', '--silent', '--prefix', tempDir, packedFile], {
+  execFileSync(npmCommand, ['install', '--silent', '--prefix', tempDir, packedFile], {
     stdio: 'inherit',
   })
 
   const packageRoot = join(tempDir, 'node_modules', '@tt-a1i', 'hive')
-  const hiveBin = join(tempDir, 'node_modules', '.bin', 'hive')
+  const hiveBin = join(tempDir, 'node_modules', '.bin', binLinkName('hive'))
   const teamBin = join(tempDir, 'node_modules', '.bin', 'team')
+  const teamCmdBin = join(tempDir, 'node_modules', '.bin', 'team.cmd')
   const internalTeam = join(packageRoot, 'dist', 'bin', 'team')
+  const internalTeamCmd = join(packageRoot, 'dist', 'bin', 'team.cmd')
 
   if (!existsSync(hiveBin)) throw new Error('Packaged hive bin was not linked')
-  if (existsSync(teamBin)) throw new Error('team must not be exposed as a global package bin')
+  if (existsSync(teamBin) || existsSync(teamCmdBin)) {
+    throw new Error('team must not be exposed as a global package bin')
+  }
   if (!existsSync(internalTeam)) throw new Error('Internal dist/bin/team is missing')
+  if (!existsSync(internalTeamCmd)) throw new Error('Internal dist/bin/team.cmd is missing')
 
   const child = spawn(hiveBin, ['--port', '0'], {
     env: {
@@ -62,6 +69,7 @@ try {
       HIVE_ORCHESTRATOR_COMMAND: process.execPath,
       HIVE_ORCHESTRATOR_ARGS_JSON: JSON.stringify(['-e', 'setInterval(() => {}, 1000)']),
     },
+    shell: process.platform === 'win32',
     stdio: ['ignore', 'pipe', 'pipe'],
   })
   let stdout = ''

--- a/scripts/pack-smoke.mjs
+++ b/scripts/pack-smoke.mjs
@@ -78,6 +78,7 @@ try {
   const teamCmdBin = join(tempDir, 'node_modules', '.bin', 'team.cmd')
   const internalTeam = join(packageRoot, 'dist', 'bin', 'team')
   const internalTeamCmd = join(packageRoot, 'dist', 'bin', 'team.cmd')
+  const internalTeamLauncher = process.platform === 'win32' ? internalTeamCmd : internalTeam
 
   if (!existsSync(hiveBin)) throw new Error('Packaged hive bin was not linked')
   if (existsSync(teamBin) || existsSync(teamCmdBin)) {
@@ -90,8 +91,8 @@ try {
     env: {
       ...process.env,
       HIVE_DATA_DIR: join(tempDir, 'data'),
-      HIVE_ORCHESTRATOR_COMMAND: process.execPath,
-      HIVE_ORCHESTRATOR_ARGS_JSON: JSON.stringify(['-e', 'setInterval(() => {}, 1000)']),
+      HIVE_ORCHESTRATOR_COMMAND: internalTeamLauncher,
+      HIVE_ORCHESTRATOR_ARGS_JSON: JSON.stringify(['list']),
     },
     shell: process.platform === 'win32',
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -120,6 +121,34 @@ try {
     const html = await response.text()
     if (!html.includes('<div id="root"></div>')) {
       throw new Error('Packaged runtime did not serve the bundled web UI')
+    }
+
+    const sessionResponse = await fetch(`http://127.0.0.1:${port}/api/ui/session`)
+    const cookie = sessionResponse.headers.get('set-cookie')?.split(';')[0]
+    if (!sessionResponse.ok || !cookie) {
+      throw new Error(`Packaged runtime session returned ${sessionResponse.status}`)
+    }
+
+    const workspaceResponse = await fetch(`http://127.0.0.1:${port}/api/workspaces`, {
+      body: JSON.stringify({
+        autostart_orchestrator: true,
+        name: 'Pack Smoke',
+        path: tempDir,
+      }),
+      headers: {
+        'content-type': 'application/json',
+        cookie,
+      },
+      method: 'POST',
+    })
+    if (workspaceResponse.status !== 201) {
+      throw new Error(`Packaged runtime workspace create returned ${workspaceResponse.status}`)
+    }
+    const workspace = await workspaceResponse.json()
+    if (workspace.orchestrator_start?.ok !== true) {
+      throw new Error(
+        `Packaged internal team launcher failed: ${workspace.orchestrator_start?.error ?? 'unknown'}`
+      )
     }
   } finally {
     await stopChild(child)

--- a/scripts/pack-smoke.mjs
+++ b/scripts/pack-smoke.mjs
@@ -6,8 +6,12 @@ import { join, resolve } from 'node:path'
 const root = process.cwd()
 const tempDir = mkdtempSync(join(tmpdir(), 'hive-pack-smoke-'))
 let packedFile
-const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
 const binLinkName = (name) => (process.platform === 'win32' ? `${name}.cmd` : name)
+
+const runNpm = (args, options = {}) =>
+  process.platform === 'win32'
+    ? execFileSync('cmd.exe', ['/d', '/s', '/c', 'npm', ...args], options)
+    : execFileSync('npm', args, options)
 
 const waitFor = async (predicate, timeoutMs = 5000) => {
   const deadline = Date.now() + timeoutMs
@@ -36,7 +40,7 @@ const stopChild = async (child) => {
 }
 
 try {
-  const packJson = execFileSync(npmCommand, ['pack', '--json'], {
+  const packJson = runNpm(['pack', '--json'], {
     cwd: root,
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'inherit'],
@@ -44,7 +48,7 @@ try {
   const [packResult] = JSON.parse(packJson)
   packedFile = resolve(root, packResult.filename)
 
-  execFileSync(npmCommand, ['install', '--silent', '--prefix', tempDir, packedFile], {
+  runNpm(['install', '--silent', '--prefix', tempDir, packedFile], {
     stdio: 'inherit',
   })
 

--- a/scripts/pack-smoke.mjs
+++ b/scripts/pack-smoke.mjs
@@ -13,6 +13,15 @@ const runNpm = (args, options = {}) =>
     ? execFileSync('cmd.exe', ['/d', '/s', '/c', 'npm', ...args], options)
     : execFileSync('npm', args, options)
 
+const removePath = (path) => {
+  rmSync(path, {
+    force: true,
+    maxRetries: process.platform === 'win32' ? 20 : 0,
+    recursive: true,
+    retryDelay: 100,
+  })
+}
+
 const waitFor = async (predicate, timeoutMs = 5000) => {
   const deadline = Date.now() + timeoutMs
   while (Date.now() <= deadline) {
@@ -35,6 +44,16 @@ const stopChild = async (child) => {
       clearTimeout(forceKill)
       resolveExit()
     })
+
+    if (process.platform === 'win32' && child.pid) {
+      try {
+        execFileSync('taskkill', ['/pid', String(child.pid), '/t', '/f'], { stdio: 'ignore' })
+      } catch {
+        child.kill('SIGKILL')
+      }
+      return
+    }
+
     child.kill('SIGTERM')
   })
 }
@@ -106,6 +125,6 @@ try {
     console.warn(stderr.trim())
   }
 } finally {
-  if (packedFile) rmSync(packedFile, { force: true })
-  rmSync(tempDir, { force: true, recursive: true })
+  if (packedFile) removePath(packedFile)
+  removePath(tempDir)
 }

--- a/scripts/pack-smoke.mjs
+++ b/scripts/pack-smoke.mjs
@@ -7,6 +7,7 @@ const root = process.cwd()
 const tempDir = mkdtempSync(join(tmpdir(), 'hive-pack-smoke-'))
 let packedFile
 const binLinkName = (name) => (process.platform === 'win32' ? `${name}.cmd` : name)
+const runtimeStartTimeoutMs = process.platform === 'win32' ? 60_000 : 5_000
 
 const runNpm = (args, options = {}) =>
   process.platform === 'win32'
@@ -108,6 +109,9 @@ try {
     const port = await waitFor(() => {
       const match = stdout.match(/Hive running at http:\/\/127\.0\.0\.1:(\d+)/)
       return match?.[1]
+    }, runtimeStartTimeoutMs).catch((error) => {
+      const childOutput = [stdout.trim(), stderr.trim()].filter(Boolean).join('\n')
+      throw new Error(`${error.message}${childOutput ? `\n${childOutput}` : ''}`)
     })
     const response = await fetch(`http://127.0.0.1:${port}/`)
     if (response.status !== 200) {

--- a/scripts/prepare-build-artifacts.mjs
+++ b/scripts/prepare-build-artifacts.mjs
@@ -1,0 +1,19 @@
+import { chmodSync, copyFileSync, existsSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = process.cwd()
+const distBin = join(root, 'dist', 'bin')
+
+const copyRequired = (source, target, mode) => {
+  const sourcePath = join(root, source)
+  if (!existsSync(sourcePath)) {
+    throw new Error(`Missing required build artifact source: ${source}`)
+  }
+  const targetPath = join(root, target)
+  copyFileSync(sourcePath, targetPath)
+  if (mode) chmodSync(targetPath, mode)
+}
+
+mkdirSync(distBin, { recursive: true })
+copyRequired('bin/team', 'dist/bin/team', 0o755)
+copyRequired('bin/team.cmd', 'dist/bin/team.cmd')

--- a/src/server/agent-command-resolver.ts
+++ b/src/server/agent-command-resolver.ts
@@ -18,10 +18,29 @@ const createCommandNotFoundError = (command: string): NodeJS.ErrnoException =>
     path: command,
   })
 
-const getWindowsExecutableNames = (command: string, env: NodeJS.ProcessEnv): string[] => {
+interface ResolvedSpawnCommand {
+  args: string[]
+  command: string
+}
+
+const getEnvValue = (
+  env: NodeJS.ProcessEnv,
+  key: string,
+  platform = process.platform
+): string | undefined => {
+  if (platform !== 'win32') return env[key]
+  const matchedKey = Object.keys(env).find((item) => item.toLowerCase() === key.toLowerCase())
+  return matchedKey ? env[matchedKey] : undefined
+}
+
+const getWindowsExecutableNames = (
+  command: string,
+  env: NodeJS.ProcessEnv,
+  platform = process.platform
+): string[] => {
   if (extname(command)) return [command]
 
-  const extensions = (env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD')
+  const extensions = (getEnvValue(env, 'PATHEXT', platform) ?? '.COM;.EXE;.BAT;.CMD')
     .split(';')
     .map((item) => item.trim())
     .filter(Boolean)
@@ -32,30 +51,59 @@ const getExecutableNames = (
   command: string,
   env: NodeJS.ProcessEnv,
   platform = process.platform
-): string[] => (platform === 'win32' ? getWindowsExecutableNames(command, env) : [command])
+): string[] =>
+  platform === 'win32' ? getWindowsExecutableNames(command, env, platform) : [command]
 
 export const resolveCommandPath = (
   command: string,
   cwd: string,
-  env: NodeJS.ProcessEnv
+  env: NodeJS.ProcessEnv,
+  platform = process.platform
 ): string => {
   if (hasPathSeparator(command)) {
-    for (const name of getExecutableNames(command, env)) {
+    for (const name of getExecutableNames(command, env, platform)) {
       const candidate = isAbsolute(name) ? name : join(cwd, name)
-      if (canExecute(candidate)) return candidate
+      if (canExecute(candidate, platform)) return candidate
     }
     throw createCommandNotFoundError(command)
   }
 
-  for (const pathEntry of (env.PATH ?? '').split(delimiter)) {
+  for (const pathEntry of (getEnvValue(env, 'PATH', platform) ?? '').split(delimiter)) {
     if (!pathEntry) continue
-    for (const name of getExecutableNames(command, env)) {
+    for (const name of getExecutableNames(command, env, platform)) {
       const candidate = join(pathEntry, name)
-      if (canExecute(candidate)) return candidate
+      if (canExecute(candidate, platform)) return candidate
     }
   }
 
   throw createCommandNotFoundError(command)
+}
+
+const isWindowsBatchFile = (command: string) => {
+  const extension = extname(command).toLowerCase()
+  return extension === '.cmd' || extension === '.bat'
+}
+
+const quoteWindowsCommandArgument = (value: string) => `"${value.replace(/"/g, '\\"')}"`
+
+const createWindowsCommandLine = (command: string, args: string[]) =>
+  [command, ...args].map(quoteWindowsCommandArgument).join(' ')
+
+export const resolveSpawnCommand = (
+  command: string,
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  args: string[] = [],
+  platform = process.platform
+): ResolvedSpawnCommand => {
+  const resolvedCommand = resolveCommandPath(command, cwd, env, platform)
+  if (platform === 'win32' && isWindowsBatchFile(resolvedCommand)) {
+    return {
+      args: ['/d', '/s', '/c', createWindowsCommandLine(resolvedCommand, args)],
+      command: getEnvValue(env, 'ComSpec', platform) ?? 'cmd.exe',
+    }
+  }
+  return { args, command: resolvedCommand }
 }
 
 export const assertCommandIsExecutable = (
@@ -65,3 +113,5 @@ export const assertCommandIsExecutable = (
 ): void => {
   resolveCommandPath(command, cwd, env)
 }
+
+export type { ResolvedSpawnCommand }

--- a/src/server/agent-command-resolver.ts
+++ b/src/server/agent-command-resolver.ts
@@ -1,11 +1,11 @@
 import { accessSync, constants } from 'node:fs'
-import { delimiter, isAbsolute, join } from 'node:path'
+import { delimiter, extname, isAbsolute, join } from 'node:path'
 
 const hasPathSeparator = (command: string) => command.includes('/') || command.includes('\\')
 
-const canExecute = (path: string): boolean => {
+const canExecute = (path: string, platform = process.platform): boolean => {
   try {
-    accessSync(path, constants.X_OK)
+    accessSync(path, platform === 'win32' ? constants.F_OK : constants.X_OK)
     return true
   } catch {
     return false
@@ -18,21 +18,50 @@ const createCommandNotFoundError = (command: string): NodeJS.ErrnoException =>
     path: command,
   })
 
-export const assertCommandIsExecutable = (
+const getWindowsExecutableNames = (command: string, env: NodeJS.ProcessEnv): string[] => {
+  if (extname(command)) return [command]
+
+  const extensions = (env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD')
+    .split(';')
+    .map((item) => item.trim())
+    .filter(Boolean)
+  return [...extensions.map((extension) => `${command}${extension}`), command]
+}
+
+const getExecutableNames = (
+  command: string,
+  env: NodeJS.ProcessEnv,
+  platform = process.platform
+): string[] => (platform === 'win32' ? getWindowsExecutableNames(command, env) : [command])
+
+export const resolveCommandPath = (
   command: string,
   cwd: string,
   env: NodeJS.ProcessEnv
-): void => {
+): string => {
   if (hasPathSeparator(command)) {
-    const candidate = isAbsolute(command) ? command : join(cwd, command)
-    if (canExecute(candidate)) return
+    for (const name of getExecutableNames(command, env)) {
+      const candidate = isAbsolute(name) ? name : join(cwd, name)
+      if (canExecute(candidate)) return candidate
+    }
     throw createCommandNotFoundError(command)
   }
 
   for (const pathEntry of (env.PATH ?? '').split(delimiter)) {
     if (!pathEntry) continue
-    if (canExecute(join(pathEntry, command))) return
+    for (const name of getExecutableNames(command, env)) {
+      const candidate = join(pathEntry, name)
+      if (canExecute(candidate)) return candidate
+    }
   }
 
   throw createCommandNotFoundError(command)
+}
+
+export const assertCommandIsExecutable = (
+  command: string,
+  cwd: string,
+  env: NodeJS.ProcessEnv
+): void => {
+  resolveCommandPath(command, cwd, env)
 }

--- a/src/server/agent-manager.ts
+++ b/src/server/agent-manager.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { spawn } from 'node-pty'
-import { resolveCommandPath } from './agent-command-resolver.js'
+import { resolveSpawnCommand } from './agent-command-resolver.js'
 import { attachAgentPty, toAgentRunSnapshot } from './agent-manager-support.js'
 import { createPtyOutputBus, type PtyOutputBus } from './pty-output-bus.js'
 
@@ -81,7 +81,7 @@ export const createAgentManager = ({
     },
     async startAgent(input) {
       const env = createSpawnEnv(input.env)
-      const command = resolveCommandPath(input.command, input.cwd, env)
+      const spawnCommand = resolveSpawnCommand(input.command, input.cwd, env, input.args ?? [])
 
       const runId = createRunId()
 
@@ -112,7 +112,7 @@ export const createAgentManager = ({
       try {
         attachAgentPty(
           run,
-          spawn(command, input.args ?? [], {
+          spawn(spawnCommand.command, spawnCommand.args, {
             cwd: input.cwd,
             env,
             name: 'xterm-256color',

--- a/src/server/agent-manager.ts
+++ b/src/server/agent-manager.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { spawn } from 'node-pty'
-import { assertCommandIsExecutable } from './agent-command-resolver.js'
+import { resolveCommandPath } from './agent-command-resolver.js'
 import { attachAgentPty, toAgentRunSnapshot } from './agent-manager-support.js'
 import { createPtyOutputBus, type PtyOutputBus } from './pty-output-bus.js'
 
@@ -81,7 +81,7 @@ export const createAgentManager = ({
     },
     async startAgent(input) {
       const env = createSpawnEnv(input.env)
-      assertCommandIsExecutable(input.command, input.cwd, env)
+      const command = resolveCommandPath(input.command, input.cwd, env)
 
       const runId = createRunId()
 
@@ -112,7 +112,7 @@ export const createAgentManager = ({
       try {
         attachAgentPty(
           run,
-          spawn(input.command, input.args ?? [], {
+          spawn(command, input.args ?? [], {
             cwd: input.cwd,
             env,
             name: 'xterm-256color',

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -4,6 +4,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from 'node:ht
 import { dirname, extname, join, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { type PickFolderResponse, pickFolder } from './fs-pick-folder.js'
 import { HttpError } from './http-errors.js'
 import { matchRoute } from './routes.js'
 import type { RuntimeStore } from './runtime-store.js'
@@ -12,6 +13,7 @@ import { createTerminalWebSocketServer } from './terminal-ws-server.js'
 
 interface CreateAppOptions {
   store: RuntimeStore
+  pickFolderService?: () => Promise<PickFolderResponse>
   tasksFileService?: TasksFileService
 }
 
@@ -91,6 +93,7 @@ const sendJson = (response: ServerResponse, statusCode: number, body: unknown) =
 
 export const createApp = ({
   store,
+  pickFolderService = pickFolder,
   tasksFileService = createTasksFileService(),
 }: CreateAppOptions) => {
   const staticDir = process.env.HIVE_STATIC_DIR ?? getDefaultStaticDir()
@@ -107,6 +110,7 @@ export const createApp = ({
           response,
           store,
           tasksFileService,
+          pickFolderService,
           params: match.params,
         })
         return

--- a/src/server/fs-pick-folder.ts
+++ b/src/server/fs-pick-folder.ts
@@ -129,6 +129,42 @@ const linuxPick = async (run: RunPickCommand): Promise<PickFolderResponse> => {
   return finalizeWithProbe(picked)
 }
 
+const windowsPick = async (run: RunPickCommand): Promise<PickFolderResponse> => {
+  const script = [
+    'Add-Type -AssemblyName System.Windows.Forms',
+    '$dialog = New-Object System.Windows.Forms.FolderBrowserDialog',
+    '$dialog.Description = "Select Hive workspace"',
+    '$dialog.ShowNewFolderButton = $false',
+    '$result = $dialog.ShowDialog()',
+    'if ($result -eq [System.Windows.Forms.DialogResult]::OK) { [Console]::Out.WriteLine($dialog.SelectedPath); exit 0 }',
+    'exit 1',
+  ].join('; ')
+  const result = await run(
+    'powershell.exe',
+    ['-NoProfile', '-STA', '-ExecutionPolicy', 'Bypass', '-Command', script],
+    {}
+  )
+  if (result.spawnError?.code === 'ENOENT') {
+    return emptyResponse({
+      error: 'PowerShell is unavailable on this host. Use Advanced: paste path.',
+      supported: false,
+    })
+  }
+  if (result.timedOut) {
+    return emptyResponse({ error: 'Folder picker timed out before a folder was selected.' })
+  }
+  if (result.status !== 0) {
+    const stderr = result.stderr.trim()
+    if (stderr.length > 0) {
+      return emptyResponse({ error: `Folder picker failed: ${stderr}` })
+    }
+    return emptyResponse({ canceled: true })
+  }
+  const picked = result.stdout.trim()
+  if (picked.length === 0) return emptyResponse({ canceled: true })
+  return finalizeWithProbe(picked)
+}
+
 export const pickFolder = async (options: PickFolderOptions = {}): Promise<PickFolderResponse> => {
   const mock = process.env.HIVE_MOCK_PICK_FOLDER
   if (mock && mock.length > 0) {
@@ -142,6 +178,7 @@ export const pickFolder = async (options: PickFolderOptions = {}): Promise<PickF
 
   if (platform === 'darwin') return macOsPick(run)
   if (platform === 'linux') return linuxPick(run)
+  if (platform === 'win32') return windowsPick(run)
   return emptyResponse({
     error: 'Native folder picker not supported on this platform. Use Advanced: paste path.',
     supported: false,

--- a/src/server/fs-pick-folder.ts
+++ b/src/server/fs-pick-folder.ts
@@ -166,13 +166,6 @@ const windowsPick = async (run: RunPickCommand): Promise<PickFolderResponse> => 
 }
 
 export const pickFolder = async (options: PickFolderOptions = {}): Promise<PickFolderResponse> => {
-  const mock = process.env.HIVE_MOCK_PICK_FOLDER
-  if (mock && mock.length > 0) {
-    if (mock === '__cancel__') return emptyResponse({ canceled: true })
-    if (mock === '__unsupported__') return emptyResponse({ supported: false })
-    return finalizeWithProbe(mock)
-  }
-
   const platform = options.platform ?? process.platform
   const run = options.runCommand ?? defaultRunCommand
 

--- a/src/server/route-types.ts
+++ b/src/server/route-types.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
 
 import type { WorkerRole } from '../shared/types.js'
+import type { PickFolderResponse } from './fs-pick-folder.js'
 import type { RuntimeStore } from './runtime-store.js'
 import type { TasksFileService } from './tasks-file.js'
 
@@ -54,6 +55,7 @@ export interface RouteContext {
   response: ServerResponse
   store: RuntimeStore
   tasksFileService: TasksFileService
+  pickFolderService: () => Promise<PickFolderResponse>
   params: Record<string, string>
 }
 

--- a/src/server/routes-fs.ts
+++ b/src/server/routes-fs.ts
@@ -1,5 +1,4 @@
 import { browseDirectory, probeDirectory } from './fs-browse.js'
-import { pickFolder } from './fs-pick-folder.js'
 import { route, sendJson } from './route-helpers.js'
 import type { RouteDefinition } from './route-types.js'
 import { requireUiTokenFromRequest } from './ui-auth-helpers.js'
@@ -20,9 +19,9 @@ export const fsRoutes: RouteDefinition[] = [
     const body = await probeDirectory(readPathParam(request))
     sendJson(response, 200, body)
   }),
-  route('POST', '/api/fs/pick-folder', async ({ request, response, store }) => {
+  route('POST', '/api/fs/pick-folder', async ({ pickFolderService, request, response, store }) => {
     requireUiTokenFromRequest(request, store.validateUiToken)
-    const body = await pickFolder()
+    const body = await pickFolderService()
     sendJson(response, 200, body)
   }),
 ]

--- a/src/server/session-capture-claude.ts
+++ b/src/server/session-capture-claude.ts
@@ -25,7 +25,7 @@ export const getClaudeProjectsRoot = (pattern?: string) => {
   return root
 }
 
-export const encodeClaudeProjectPath = (cwd: string) => cwd.replace(/[/:\s]/g, '-')
+export const encodeClaudeProjectPath = (cwd: string) => cwd.replace(/[\\/:\s]/g, '-')
 
 const listSessionIds = (cwd: string, projectsRoot = getDefaultProjectsRoot()) => {
   const projectDir = join(projectsRoot, encodeClaudeProjectPath(cwd))

--- a/tests/helpers/test-server.ts
+++ b/tests/helpers/test-server.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path'
 
 import { createAgentManager } from '../../src/server/agent-manager.js'
 import { createApp } from '../../src/server/app.js'
+import { probeDirectory } from '../../src/server/fs-browse.js'
+import type { PickFolderResponse } from '../../src/server/fs-pick-folder.js'
 import { createRuntimeStore } from '../../src/server/runtime-store.js'
 
 interface TestServerContext {
@@ -14,12 +16,27 @@ interface TestServerContext {
 }
 
 export const startTestServer = async (
-  input: { dataDir?: string } = {}
+  input: {
+    dataDir?: string
+    pickFolderPath?: string
+    pickFolderService?: () => Promise<PickFolderResponse>
+  } = {}
 ): Promise<TestServerContext> => {
   const ownsDataDir = !input.dataDir
   const dataDir = input.dataDir ?? mkdtempSync(join(tmpdir(), 'hive-test-server-'))
   const store = createRuntimeStore({ agentManager: createAgentManager(), dataDir })
-  const app = createApp({ store })
+  const pickFolderService =
+    input.pickFolderService ??
+    (input.pickFolderPath
+      ? async () => ({
+          canceled: false,
+          error: null,
+          path: input.pickFolderPath ?? null,
+          probe: input.pickFolderPath ? await probeDirectory(input.pickFolderPath) : null,
+          supported: true,
+        })
+      : undefined)
+  const app = createApp({ pickFolderService, store })
 
   await new Promise<void>((resolve) => {
     app.server.listen(0, '127.0.0.1', () => resolve())

--- a/tests/integration/hive-runtime-sigterm.test.ts
+++ b/tests/integration/hive-runtime-sigterm.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, test } from 'vitest'
 
 const tempDirs: string[] = []
+const describeUnixOnly = process.platform === 'win32' ? describe.skip : describe
 
 const waitFor = async (
   assertion: () => void | Promise<void>,
@@ -34,7 +35,7 @@ afterEach(() => {
   }
 })
 
-describe('hive runtime SIGTERM shutdown', () => {
+describeUnixOnly('hive runtime SIGTERM shutdown', () => {
   test('SIGTERM exits runtime and cleans up active PTY child', async () => {
     const root = mkdtempSync(join(tmpdir(), 'hive-sigterm-test-'))
     const workspacePath = join(root, 'workspace')
@@ -52,7 +53,7 @@ describe('hive runtime SIGTERM shutdown', () => {
         "import { runHiveCommand } from './src/cli/hive.ts'; await runHiveCommand(['--port','40128']);",
       ],
       {
-        cwd: '/Users/admin/code/hive',
+        cwd: process.cwd(),
         env: { ...process.env, HIVE_DATA_DIR: join(root, 'data') },
         stdio: 'ignore',
       }

--- a/tests/integration/package-tarball.test.ts
+++ b/tests/integration/package-tarball.test.ts
@@ -14,12 +14,14 @@ interface PackResult {
   version: string
 }
 
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+
 describe('npm package tarball', () => {
   test('publish dry-run exposes only runtime files and the hive bin', () => {
     expect(existsSync(join(process.cwd(), 'dist', 'src', 'cli', 'hive.js'))).toBe(true)
     expect(existsSync(join(process.cwd(), 'web', 'dist', 'index.html'))).toBe(true)
 
-    const output = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+    const output = execFileSync(npmCommand, ['pack', '--dry-run', '--json'], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
     })
@@ -31,6 +33,7 @@ describe('npm package tarball', () => {
     expect(paths).toContain('dist/src/cli/hive.js')
     expect(paths).toContain('dist/src/cli/team.js')
     expect(paths).toContain('dist/bin/team')
+    expect(paths).toContain('dist/bin/team.cmd')
     expect(paths).toContain('web/dist/index.html')
     expect(paths).toContain('scripts/fix-runtime-artifacts.mjs')
     expect(paths).toContain('CHANGELOG.md')

--- a/tests/integration/package-tarball.test.ts
+++ b/tests/integration/package-tarball.test.ts
@@ -14,17 +14,22 @@ interface PackResult {
   version: string
 }
 
-const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+const runNpm = (args: string[]) =>
+  execFileSync(
+    process.platform === 'win32' ? 'cmd.exe' : 'npm',
+    process.platform === 'win32' ? ['/d', '/s', '/c', 'npm', ...args] : args,
+    {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  )
 
 describe('npm package tarball', () => {
   test('publish dry-run exposes only runtime files and the hive bin', () => {
     expect(existsSync(join(process.cwd(), 'dist', 'src', 'cli', 'hive.js'))).toBe(true)
     expect(existsSync(join(process.cwd(), 'web', 'dist', 'index.html'))).toBe(true)
 
-    const output = execFileSync(npmCommand, ['pack', '--dry-run', '--json'], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    })
+    const output = runNpm(['pack', '--dry-run', '--json'])
     const [result] = JSON.parse(output) as PackResult[]
     const paths = result.files.map((file) => file.path)
 

--- a/tests/server/fs-pick-folder.test.ts
+++ b/tests/server/fs-pick-folder.test.ts
@@ -22,12 +22,10 @@ beforeEach(() => {
   writeFileSync(join(insideDir, '.git', 'HEAD'), 'ref: refs/heads/main\n')
   mkdirSync(outsideDir, { recursive: true })
   process.env.HIVE_FS_BROWSE_ROOT = sandboxRoot
-  delete process.env.HIVE_MOCK_PICK_FOLDER
 })
 
 afterEach(() => {
   delete process.env.HIVE_FS_BROWSE_ROOT
-  delete process.env.HIVE_MOCK_PICK_FOLDER
   vi.restoreAllMocks()
   for (const dir of tempDirs.splice(0)) rmSync(dir, { force: true, recursive: true })
 })
@@ -156,26 +154,5 @@ describe('pickFolder — platform dispatch', () => {
     const result = await pickFolder({ platform: 'darwin', runCommand })
     expect(result.canceled).toBe(false)
     expect(result.error).toMatch(/timed out/)
-  })
-})
-
-describe('pickFolder — HIVE_MOCK_PICK_FOLDER smoke hook', () => {
-  test('mock path short-circuits the native picker and still runs probeDirectory', async () => {
-    process.env.HIVE_MOCK_PICK_FOLDER = insideDir
-    const result = await pickFolder({ platform: 'darwin' })
-    expect(result.path).toBe(insideDir)
-    expect(result.probe?.ok).toBe(true)
-  })
-
-  test('__cancel__ sentinel yields canceled=true', async () => {
-    process.env.HIVE_MOCK_PICK_FOLDER = '__cancel__'
-    const result = await pickFolder()
-    expect(result.canceled).toBe(true)
-  })
-
-  test('__unsupported__ sentinel yields supported=false', async () => {
-    process.env.HIVE_MOCK_PICK_FOLDER = '__unsupported__'
-    const result = await pickFolder()
-    expect(result.supported).toBe(false)
   })
 })

--- a/tests/server/fs-pick-folder.test.ts
+++ b/tests/server/fs-pick-folder.test.ts
@@ -93,8 +93,34 @@ describe('pickFolder — platform dispatch', () => {
     expect(result.error).toBeNull()
   })
 
-  test('win32 (and other platforms): returns supported=false with guidance', async () => {
-    const result = await pickFolder({ platform: 'win32' })
+  test('win32: PowerShell folder picker stdout path flows through probeDirectory', async () => {
+    const calls: Array<{ command: string; args: string[]; timeout: unknown }> = []
+    const runCommand: RunPickCommand = async (command, args, options) => {
+      calls.push({ command, args, timeout: options.timeout })
+      return { ...emptySpawn, stdout: `${insideDir}\r\n` }
+    }
+    const result = await pickFolder({ platform: 'win32', runCommand })
+    expect(result.canceled).toBe(false)
+    expect(result.supported).toBe(true)
+    expect(result.path).toBe(insideDir)
+    expect(result.probe?.ok).toBe(true)
+    expect(calls[0]?.command).toBe('powershell.exe')
+    expect(calls[0]?.args).toContain('-STA')
+    expect(calls[0]?.args.join(' ')).toContain('FolderBrowserDialog')
+    expect(calls[0]?.timeout).toBeUndefined()
+  })
+
+  test('win32: PowerShell cancel exits without an error', async () => {
+    const runCommand: RunPickCommand = async () => ({ ...emptySpawn, status: 1 })
+    const result = await pickFolder({ platform: 'win32', runCommand })
+    expect(result.canceled).toBe(true)
+    expect(result.error).toBeNull()
+    expect(result.supported).toBe(true)
+    expect(result.path).toBeNull()
+  })
+
+  test('other unsupported platforms still fall back to Advanced paste path', async () => {
+    const result = await pickFolder({ platform: 'freebsd' })
     expect(result.supported).toBe(false)
     expect(result.canceled).toBe(false)
     expect(result.error).toMatch(/Advanced: paste path/)

--- a/tests/server/runtime-rehydration.test.ts
+++ b/tests/server/runtime-rehydration.test.ts
@@ -1,6 +1,6 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { delimiter, join } from 'node:path'
 
 import Database from 'better-sqlite3'
 import { afterEach, describe, expect, test, vi } from 'vitest'
@@ -9,8 +9,27 @@ import { createAgentManager } from '../../src/server/agent-manager.js'
 import { createRuntimeStore } from '../../src/server/runtime-store.js'
 
 const tempDirs: string[] = []
+const originalPath = process.env.PATH
+const stores: Array<ReturnType<typeof createRuntimeStore>> = []
 
-afterEach(() => {
+const writeFakeClaudeCli = (binDir: string) => {
+  const scriptPath = join(binDir, 'fake-claude.js')
+  writeFileSync(scriptPath, 'process.stdin.resume(); setInterval(() => {}, 1000)\n')
+
+  const unixCli = join(binDir, 'claude')
+  writeFileSync(unixCli, `#!/usr/bin/env sh\nexec "${process.execPath}" "${scriptPath}" "$@"\n`)
+  chmodSync(unixCli, 0o755)
+
+  const winCli = join(binDir, 'claude.cmd')
+  writeFileSync(winCli, `@echo off\r\n"${process.execPath}" "%~dp0fake-claude.js" %*\r\n`)
+}
+
+afterEach(async () => {
+  for (const store of stores.splice(0)) {
+    await store.close()
+  }
+  process.env.PATH = originalPath
+  delete process.env.HIVE_CLAUDE_PROJECTS_DIR
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { force: true, recursive: true })
   }
@@ -22,6 +41,7 @@ describe('runtime rehydration', () => {
     tempDirs.push(dataDir)
 
     const firstStore = createRuntimeStore({ dataDir })
+    stores.push(firstStore)
     const workspace = firstStore.createWorkspace('/tmp/hive-alpha', 'Alpha')
     const alice = firstStore.addWorker(workspace.id, { name: 'Alice', role: 'coder' })
     const bob = firstStore.addWorker(workspace.id, { name: 'Bob', role: 'tester' })
@@ -31,6 +51,7 @@ describe('runtime rehydration', () => {
     firstStore.reportTask(workspace.id, bob.id)
 
     const secondStore = createRuntimeStore({ dataDir })
+    stores.push(secondStore)
 
     expect(secondStore.listWorkers(workspace.id)).toEqual([
       {
@@ -54,11 +75,16 @@ describe('runtime rehydration', () => {
     const dataDir = mkdtempSync(join(tmpdir(), 'hive-runtime-session-'))
     const workspacePath = join(dataDir, 'workspace')
     const claudeProjectsDir = join(dataDir, 'claude-projects')
+    const binDir = join(dataDir, 'bin')
     tempDirs.push(dataDir)
     mkdirSync(workspacePath, { recursive: true })
+    mkdirSync(binDir, { recursive: true })
     mkdirSync(join(claudeProjectsDir, '-tmp-hive-alpha'), { recursive: true })
+    writeFakeClaudeCli(binDir)
+    process.env.PATH = `${binDir}${delimiter}${originalPath ?? ''}`
 
     const firstStore = createRuntimeStore({ agentManager: createAgentManager(), dataDir })
+    stores.push(firstStore)
     const workspace = firstStore.createWorkspace('/tmp/hive-alpha', 'Alpha')
     const worker = firstStore.addWorker(workspace.id, { name: 'Alice', role: 'coder' })
     firstStore.configureAgentLaunch(workspace.id, worker.id, {
@@ -82,6 +108,7 @@ describe('runtime rehydration', () => {
     const startSpy = vi.spyOn(manager, 'startAgent')
 
     const secondStore = createRuntimeStore({ agentManager: manager, dataDir })
+    stores.push(secondStore)
     secondStore.configureAgentLaunch(workspace.id, worker.id, {
       command: 'claude',
       args: ['--dangerously-skip-permissions'],
@@ -111,6 +138,7 @@ describe('runtime rehydration', () => {
     db.close()
 
     const thirdStore = createRuntimeStore({ agentManager: manager, dataDir })
+    stores.push(thirdStore)
     thirdStore.configureAgentLaunch(workspace.id, worker.id, {
       command: 'claude',
       args: ['--dangerously-skip-permissions'],

--- a/tests/server/schema-version.test.ts
+++ b/tests/server/schema-version.test.ts
@@ -9,10 +9,12 @@ import { createRuntimeStore } from '../../src/server/runtime-store.js'
 import { initializeRuntimeDatabase } from '../../src/server/sqlite-schema.js'
 
 const tempDirs: string[] = []
+const stores: Array<ReturnType<typeof createRuntimeStore>> = []
 
-afterEach(() => {
+afterEach(async () => {
+  await Promise.all(stores.splice(0).map((store) => store.close()))
   for (const dir of tempDirs.splice(0)) {
-    rmSync(dir, { force: true, recursive: true })
+    rmSync(dir, { force: true, maxRetries: 10, recursive: true, retryDelay: 100 })
   }
 })
 
@@ -36,7 +38,7 @@ describe('schema version', () => {
     const dataDir = mkdtempSync(join(tmpdir(), 'hive-schema-version-'))
     tempDirs.push(dataDir)
 
-    createRuntimeStore({ dataDir })
+    stores.push(createRuntimeStore({ dataDir }))
 
     const db = new Database(join(dataDir, 'runtime.sqlite'), { readonly: true })
     const row = db
@@ -51,7 +53,7 @@ describe('schema version', () => {
     const dataDir = mkdtempSync(join(tmpdir(), 'hive-schema-columns-'))
     tempDirs.push(dataDir)
 
-    createRuntimeStore({ dataDir })
+    stores.push(createRuntimeStore({ dataDir }))
 
     const db = new Database(join(dataDir, 'runtime.sqlite'), { readonly: true })
     const workerColumns = new Set(

--- a/tests/unit/agent-command-resolver.test.ts
+++ b/tests/unit/agent-command-resolver.test.ts
@@ -1,0 +1,43 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
+
+import { afterEach, describe, expect, test } from 'vitest'
+
+import {
+  assertCommandIsExecutable,
+  resolveCommandPath,
+} from '../../src/server/agent-command-resolver.js'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { force: true, recursive: true })
+  }
+})
+
+describe('agent command resolver', () => {
+  test('accepts executable commands already present on PATH', () => {
+    expect(() =>
+      assertCommandIsExecutable(process.execPath, process.cwd(), process.env)
+    ).not.toThrow()
+  })
+
+  test('uses PATHEXT candidates before extensionless scripts on Windows', () => {
+    if (process.platform !== 'win32') return
+
+    const root = mkdtempSync(join(tmpdir(), 'hive-command-resolver-'))
+    tempDirs.push(root)
+    const binDir = join(root, 'bin')
+    mkdirSync(binDir, { recursive: true })
+    writeFileSync(join(binDir, 'agent'), 'extensionless placeholder')
+    writeFileSync(join(binDir, 'agent.cmd'), '@echo off\r\n')
+
+    const resolved = resolveCommandPath('agent', root, {
+      PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
+      PATHEXT: '.CMD;.EXE',
+    })
+    expect(resolved.toLowerCase()).toBe(join(binDir, 'agent.cmd').toLowerCase())
+  })
+})

--- a/tests/unit/agent-command-resolver.test.ts
+++ b/tests/unit/agent-command-resolver.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, test } from 'vitest'
 import {
   assertCommandIsExecutable,
   resolveCommandPath,
+  resolveSpawnCommand,
 } from '../../src/server/agent-command-resolver.js'
 
 const tempDirs: string[] = []
@@ -25,8 +26,6 @@ describe('agent command resolver', () => {
   })
 
   test('uses PATHEXT candidates before extensionless scripts on Windows', () => {
-    if (process.platform !== 'win32') return
-
     const root = mkdtempSync(join(tmpdir(), 'hive-command-resolver-'))
     tempDirs.push(root)
     const binDir = join(root, 'bin')
@@ -34,10 +33,41 @@ describe('agent command resolver', () => {
     writeFileSync(join(binDir, 'agent'), 'extensionless placeholder')
     writeFileSync(join(binDir, 'agent.cmd'), '@echo off\r\n')
 
-    const resolved = resolveCommandPath('agent', root, {
-      PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
-      PATHEXT: '.CMD;.EXE',
-    })
+    const resolved = resolveCommandPath(
+      'agent',
+      root,
+      {
+        Path: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
+        PathExt: '.cmd;.EXE',
+      },
+      'win32'
+    )
     expect(resolved.toLowerCase()).toBe(join(binDir, 'agent.cmd').toLowerCase())
+  })
+
+  test('wraps Windows command shims with cmd.exe for PTY spawn', () => {
+    const root = mkdtempSync(join(tmpdir(), 'hive-command-spawn-'))
+    tempDirs.push(root)
+    const binDir = join(root, 'bin')
+    const commandPath = join(binDir, 'agent.cmd')
+    mkdirSync(binDir, { recursive: true })
+    writeFileSync(commandPath, '@echo off\r\n')
+
+    const resolved = resolveSpawnCommand(
+      'agent',
+      root,
+      {
+        ComSpec: 'C:\\Windows\\System32\\cmd.exe',
+        Path: binDir,
+        PathExt: '.cmd;.EXE',
+      },
+      ['--flag', 'value with spaces'],
+      'win32'
+    )
+
+    expect(resolved).toEqual({
+      args: ['/d', '/s', '/c', `"${commandPath}" "--flag" "value with spaces"`],
+      command: 'C:\\Windows\\System32\\cmd.exe',
+    })
   })
 })

--- a/tests/unit/claude-session-support.test.ts
+++ b/tests/unit/claude-session-support.test.ts
@@ -39,6 +39,10 @@ afterEach(() => {
 })
 
 describe('claude session support', () => {
+  test('encodeClaudeProjectPath handles Windows separators', () => {
+    expect(encodeClaudeProjectPath('C:\\Users\\admin\\project')).toBe('C--Users-admin-project')
+  })
+
   test('snapshotClaudeSessionIds returns an empty set when the project directory is missing', () => {
     createTempRoot()
 

--- a/tests/web/app-shell.test.tsx
+++ b/tests/web/app-shell.test.tsx
@@ -22,9 +22,10 @@ beforeEach(async () => {
   mkdirSync(join(sandboxRoot, 'placeholder'), { recursive: true })
   tempDirs.push(sandboxRoot)
   process.env.HIVE_FS_BROWSE_ROOT = sandboxRoot
-  process.env.HIVE_MOCK_PICK_FOLDER = join(sandboxRoot, 'placeholder')
 
-  const server = await startTestServer()
+  const server = await startTestServer({
+    pickFolderPath: join(sandboxRoot, 'placeholder'),
+  })
   cleanupServer = server.close
   let cookie = ''
   await nativeFetch(`${server.baseUrl}/api/ui/session`).then((response) => {
@@ -49,7 +50,6 @@ afterEach(async () => {
   await cleanupServer?.()
   cleanupServer = undefined
   delete process.env.HIVE_FS_BROWSE_ROOT
-  delete process.env.HIVE_MOCK_PICK_FOLDER
   for (const dir of tempDirs.splice(0)) rmSync(dir, { force: true, recursive: true })
 })
 

--- a/tests/web/workspace-create-initial-state.test.tsx
+++ b/tests/web/workspace-create-initial-state.test.tsx
@@ -20,9 +20,10 @@ beforeEach(async () => {
   mkdirSync(join(sandboxRoot, 'alpha-project'), { recursive: true })
   tempDirs.push(sandboxRoot)
   process.env.HIVE_FS_BROWSE_ROOT = sandboxRoot
-  process.env.HIVE_MOCK_PICK_FOLDER = join(sandboxRoot, 'alpha-project')
 
-  const server = await startTestServer()
+  const server = await startTestServer({
+    pickFolderPath: join(sandboxRoot, 'alpha-project'),
+  })
   cleanupServer = server.close
   let cookie = ''
   await nativeFetch(`${server.baseUrl}/api/ui/session`).then((response) => {
@@ -44,7 +45,6 @@ afterEach(async () => {
   await cleanupServer?.()
   cleanupServer = undefined
   delete process.env.HIVE_FS_BROWSE_ROOT
-  delete process.env.HIVE_MOCK_PICK_FOLDER
   for (const dir of tempDirs.splice(0)) rmSync(dir, { force: true, recursive: true })
 })
 

--- a/tests/web/workspace-flow.test.tsx
+++ b/tests/web/workspace-flow.test.tsx
@@ -101,7 +101,7 @@ describe('workspace flow with real server', () => {
       () => {
         expect(document.querySelector('[data-pty-slot="orchestrator"]')).not.toBeNull()
       },
-      { timeout: 3000 }
+      { timeout: 10_000 }
     )
     expect(screen.queryByTestId('orchestrator-starting-body')).toBeNull()
     expect(screen.queryByTestId('orchestrator-failed-body')).toBeNull()
@@ -143,7 +143,7 @@ describe('workspace flow with real server', () => {
       () => {
         expect(document.querySelector('[data-pty-slot="orchestrator"]')).not.toBeNull()
       },
-      { timeout: 3000 }
+      { timeout: 10_000 }
     )
     expect(screen.queryByTestId('orchestrator-starting-body')).toBeNull()
     expect(screen.queryByTestId('orchestrator-failed-body')).toBeNull()

--- a/tests/web/workspace-flow.test.tsx
+++ b/tests/web/workspace-flow.test.tsx
@@ -23,10 +23,9 @@ beforeEach(async () => {
   mkdirSync(join(sandboxRoot, 'alpha-project'), { recursive: true })
   tempDirs.push(sandboxRoot)
   process.env.HIVE_FS_BROWSE_ROOT = sandboxRoot
-  // Short-circuit the native folder picker so the test doesn't actually spawn
-  // osascript/zenity. The value mimics what the OS dialog would return.
-  process.env.HIVE_MOCK_PICK_FOLDER = join(sandboxRoot, 'alpha-project')
-  const server = await startTestServer()
+  const server = await startTestServer({
+    pickFolderPath: join(sandboxRoot, 'alpha-project'),
+  })
   serverContext = server
   dummyPresetId = server.store.settings.createCommandPreset({
     args: ['-e', "console.log('queen port:' + process.env.HIVE_PORT); process.stdin.resume()"],
@@ -59,7 +58,6 @@ afterEach(async () => {
   cleanupServer = undefined
   serverContext = undefined
   delete process.env.HIVE_FS_BROWSE_ROOT
-  delete process.env.HIVE_MOCK_PICK_FOLDER
   dummyPresetId = ''
   for (const dir of tempDirs.splice(0)) rmSync(dir, { force: true, recursive: true })
 })

--- a/tests/web/workspace-flow.test.tsx
+++ b/tests/web/workspace-flow.test.tsx
@@ -120,7 +120,7 @@ describe('workspace flow with real server', () => {
     // 0 workers in a fresh workspace → EmptyState (no worker-grid until ≥1).
     expect(screen.getByTestId('add-worker-empty')).toBeInTheDocument()
     expect(screen.getByTestId('task-graph-drawer')).toBeInTheDocument()
-  })
+  }, 20_000)
 
   test('existing workspace auto-starts Queen without exposing a manual Start Queen CTA', async () => {
     const existingPath = join(sandboxRoot, 'existing-project')
@@ -147,5 +147,5 @@ describe('workspace flow with real server', () => {
     )
     expect(screen.queryByTestId('orchestrator-starting-body')).toBeNull()
     expect(screen.queryByTestId('orchestrator-failed-body')).toBeNull()
-  })
+  }, 20_000)
 })

--- a/tests/web/workspace-flow.test.tsx
+++ b/tests/web/workspace-flow.test.tsx
@@ -7,6 +7,7 @@ import { join } from 'node:path'
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
+import { seedOrchestratorLaunchConfig } from '../../src/server/orchestrator-launch.js'
 import { App } from '../../web/src/app.js'
 import { startTestServer } from '../helpers/test-server.js'
 
@@ -125,7 +126,14 @@ describe('workspace flow with real server', () => {
   test('existing workspace auto-starts Queen without exposing a manual Start Queen CTA', async () => {
     const existingPath = join(sandboxRoot, 'existing-project')
     mkdirSync(existingPath, { recursive: true })
-    serverContext?.store.createWorkspace(existingPath, 'Existing')
+    const existing = serverContext?.store.createWorkspace(existingPath, 'Existing')
+    if (!serverContext || !existing) throw new Error('Expected test server')
+    seedOrchestratorLaunchConfig(
+      serverContext.store,
+      serverContext.store.settings,
+      existing.id,
+      dummyPresetId
+    )
 
     render(<App />)
 


### PR DESCRIPTION
## Summary
- add native Windows folder picker support through PowerShell
- package internal team.cmd and make build/pack smoke cross-platform
- add windows-latest to release verification matrix
- update README platform support and troubleshooting

## Verification
- pnpm check
- pnpm build
- pnpm exec vitest run tests/server/fs-pick-folder.test.ts tests/integration/package-tarball.test.ts
- pnpm pack:smoke
- pnpm test
- pnpm pack:check