### PR TITLE
Treat terminal dispatch states as closed

### DIFF
--- a/scripts/hive-resync.sh
+++ b/scripts/hive-resync.sh
@@ -11,9 +11,14 @@
 #   hive-resync --fix              mark all non-terminal dispatches reported
 #   hive-resync --restart          kill the Hive runtime (you re-launch in UI)
 #   hive-resync --fix --restart    both - typical recovery flow
+#   hive-resync --watch [--interval SEC] [--idle-min MIN]
+#                                  daemon mode: every SEC seconds, close
+#                                  dispatches submitted more than MIN minutes
+#                                  ago with no recent worker activity.
+#                                  Defaults: interval=60, idle-min=3.
 #   hive-resync --help             this message
 #
-# The DB is backed up to runtime.sqlite.bak.<ts> before any write.
+# The DB is backed up to runtime.sqlite.bak.<ts> before any --fix write.
 # Honors HIVE_DB env var (default: ~/.config/hive/runtime.sqlite).
 
 set -euo pipefail
@@ -21,13 +26,19 @@ set -euo pipefail
 DB="${HIVE_DB:-$HOME/.config/hive/runtime.sqlite}"
 APPLY=false
 RESTART=false
+WATCH=false
+INTERVAL=60
+IDLE_MIN=3
 
-for arg in "$@"; do
-    case "$arg" in
-        --fix) APPLY=true ;;
-        --restart) RESTART=true ;;
-        -h|--help) sed -n '2,18p' "$0"; exit 0 ;;
-        *) echo "Unknown arg: $arg" >&2; exit 2 ;;
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --fix) APPLY=true; shift ;;
+        --restart) RESTART=true; shift ;;
+        --watch) WATCH=true; shift ;;
+        --interval) INTERVAL="$2"; shift 2 ;;
+        --idle-min) IDLE_MIN="$2"; shift 2 ;;
+        -h|--help) sed -n '2,21p' "$0"; exit 0 ;;
+        *) echo "Unknown arg: $1" >&2; exit 2 ;;
     esac
 done
 
@@ -36,6 +47,93 @@ if [ ! -f "$DB" ]; then
     exit 1
 fi
 
+# Watch mode: daemon loop closing idle dispatches based on last worker message.
+if [ "$WATCH" = true ]; then
+    # Don't exit on individual command errors; the daemon must survive
+    # transient sqlite "database is locked" errors when the Hive runtime
+    # is actively writing.
+    set +e
+    echo "hive-resync watchdog started (interval=${INTERVAL}s, idle-min=${IDLE_MIN}m)"
+    echo "DB: $DB"
+    echo "Press Ctrl-C to stop"
+    # Use sqlite -cmd to retry busy database for up to 5s on each query.
+    SQLITE_OPTS=(-cmd ".timeout 5000")
+    while true; do
+        # Hang detection: dispatch with NO follow-up activity from worker
+        # for longer than HANG_MIN minutes. Likely PTY stuck (opencode/codex
+        # loop, LLM hang, blocked on prompt). We do NOT auto-close — user
+        # decides whether to interrupt. Just log loudly so user notices.
+        HANG_MIN=10
+        HUNG=$(sqlite3 "${SQLITE_OPTS[@]}" "$DB" "
+          SELECT d.id || ' | worker=' || w.name || ' | submitted=' ||
+                 datetime(d.created_at/1000,'unixepoch','localtime') ||
+                 ' | minutes_silent=' ||
+                 CAST((strftime('%s','now') * 1000 - d.created_at) / 60000 AS INTEGER)
+          FROM dispatches d
+          JOIN workers w ON w.id = d.to_agent_id
+          LEFT JOIN (
+            SELECT worker_id, MAX(created_at) AS last_at
+            FROM messages
+            WHERE type IN ('report','status')
+            GROUP BY worker_id
+          ) m ON m.worker_id = d.to_agent_id
+          WHERE d.status NOT IN ('reported','cancelled','failed')
+            AND (m.last_at IS NULL OR m.last_at < d.created_at)
+            AND (strftime('%s','now') * 1000 - d.created_at) > ${HANG_MIN} * 60 * 1000
+          ORDER BY d.created_at ASC;
+        " 2>/dev/null)
+        if [ -n "$HUNG" ]; then
+            echo "$(date '+%H:%M:%S') ⚠ HUNG dispatch(es) — worker may need manual interrupt:"
+            echo "$HUNG" | sed 's/^/    /'
+        fi
+
+        # For each non-terminal dispatch, check if its worker has a more
+        # recent report/status message after the dispatch was created. If
+        # yes AND that activity is older than idle-min minutes, close the
+        # dispatch. This catches the common case of workers reporting via
+        # team status (which does not auto-close) or reporting without
+        # --dispatch in a way that leaked stale rows.
+        CLOSED=$(sqlite3 "${SQLITE_OPTS[@]}" "$DB" "
+          WITH stale_dispatches AS (
+            SELECT d.id AS dispatch_id, d.to_agent_id, d.created_at
+            FROM dispatches d
+            WHERE d.status NOT IN ('reported', 'cancelled', 'failed')
+          ),
+          last_worker_activity AS (
+            SELECT s.dispatch_id,
+                   (SELECT MAX(m.created_at)
+                    FROM messages m
+                    WHERE m.worker_id = s.to_agent_id
+                      AND m.created_at > s.created_at
+                      AND m.type IN ('report', 'status'))
+                   AS last_msg_at
+            FROM stale_dispatches s
+          )
+          SELECT s.dispatch_id
+          FROM stale_dispatches s
+          JOIN last_worker_activity a ON a.dispatch_id = s.dispatch_id
+          WHERE a.last_msg_at IS NOT NULL
+            AND (strftime('%s','now') * 1000 - a.last_msg_at) > ${IDLE_MIN} * 60 * 1000;
+        ")
+        if [ -n "$CLOSED" ]; then
+            COUNT=$(echo "$CLOSED" | wc -l | tr -d ' ')
+            echo "$(date '+%H:%M:%S') closing $COUNT stale dispatch(es):"
+            echo "$CLOSED" | sed 's/^/    /'
+            for id in $CLOSED; do
+                sqlite3 "${SQLITE_OPTS[@]}" "$DB" "
+                  UPDATE dispatches
+                  SET status='reported',
+                      reported_at=strftime('%s','now') * 1000,
+                      report_text=COALESCE(report_text, 'auto-closed by hive-resync watchdog after ${IDLE_MIN}m idle')
+                  WHERE id='$id' AND status NOT IN ('reported','cancelled','failed');
+                " 2>/dev/null || echo "$(date '+%H:%M:%S') warn: failed to close $id (db locked, will retry next tick)"
+            done
+        fi
+        sleep "$INTERVAL"
+    done
+fi
+
+# One-shot mode (default + --fix + --restart)
 echo "=== Hive runtime DB: $DB ==="
 echo
 echo "=== Non-terminal dispatches (status not in 'reported'/'cancelled'/'failed') ==="
@@ -93,8 +191,10 @@ if [ "$RESTART" = true ]; then
     fi
 fi
 
-if [ "$APPLY" = false ] && [ "$RESTART" = false ]; then
+if [ "$APPLY" = false ] && [ "$RESTART" = false ] && [ "$WATCH" = false ]; then
     echo
-    echo "Dry run. Pass --fix to mark these as reported, --restart to kill the daemon."
-    echo "Typical recovery: hive-resync --fix --restart"
+    echo "Dry run. Pass --fix to mark these as reported, --restart to kill"
+    echo "the daemon, or --watch to run as a background watchdog daemon."
+    echo "Typical one-shot recovery: hive-resync --fix --restart"
+    echo "Typical always-on usage:  hive-resync --watch &  (run on session start)"
 fi

--- a/scripts/hive-resync.sh
+++ b/scripts/hive-resync.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# hive-resync - Restore Hive worker pending counters by force-closing stuck
+# dispatches in ~/.config/hive/runtime.sqlite, then optionally kill the
+# runtime daemon so it re-hydrates clean on next launch.
+#
+# Pairs with the local patch in dispatch-ledger-store.{ts,js} that treats
+# 'cancelled' and 'failed' as terminal during hydration.
+#
+# Usage:
+#   hive-resync                    diagnose only (default, no writes)
+#   hive-resync --fix              mark all non-terminal dispatches reported
+#   hive-resync --restart          kill the Hive runtime (you re-launch in UI)
+#   hive-resync --fix --restart    both - typical recovery flow
+#   hive-resync --help             this message
+#
+# The DB is backed up to runtime.sqlite.bak.<ts> before any write.
+# Honors HIVE_DB env var (default: ~/.config/hive/runtime.sqlite).
+
+set -euo pipefail
+
+DB="${HIVE_DB:-$HOME/.config/hive/runtime.sqlite}"
+APPLY=false
+RESTART=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --fix) APPLY=true ;;
+        --restart) RESTART=true ;;
+        -h|--help) sed -n '2,18p' "$0"; exit 0 ;;
+        *) echo "Unknown arg: $arg" >&2; exit 2 ;;
+    esac
+done
+
+if [ ! -f "$DB" ]; then
+    echo "DB not found: $DB" >&2
+    exit 1
+fi
+
+echo "=== Hive runtime DB: $DB ==="
+echo
+echo "=== Non-terminal dispatches (status not in 'reported'/'cancelled'/'failed') ==="
+sqlite3 -header -column "$DB" "
+  SELECT d.id, w.name AS worker, d.status,
+         substr(d.text, 1, 50) AS task_preview,
+         datetime(d.created_at/1000, 'unixepoch', 'localtime') AS created
+  FROM dispatches d
+  LEFT JOIN workers w ON w.id = d.to_agent_id
+  WHERE d.status NOT IN ('reported', 'cancelled', 'failed')
+  ORDER BY d.sequence DESC
+  LIMIT 50;
+"
+
+OPEN_COUNT=$(sqlite3 "$DB" "SELECT count(*) FROM dispatches WHERE status NOT IN ('reported','cancelled','failed');")
+echo
+echo "=== Non-terminal dispatch count: $OPEN_COUNT ==="
+echo
+
+HIVE_PID="$(lsof "$DB" 2>/dev/null | awk 'NR==2 {print $2}' || true)"
+if [ -n "${HIVE_PID:-}" ]; then
+    HIVE_ETIME="$(ps -p "$HIVE_PID" -o etime= 2>/dev/null | tr -d ' ' || echo unknown)"
+    echo "Hive runtime: pid $HIVE_PID, uptime $HIVE_ETIME"
+else
+    echo "Hive runtime: not running (no process holds the DB)"
+fi
+
+if [ "$APPLY" = true ] && [ "$OPEN_COUNT" -gt 0 ]; then
+    BACKUP="${DB}.bak.$(date +%Y%m%d-%H%M%S)"
+    cp "$DB" "$BACKUP"
+    echo "DB backed up to: $BACKUP"
+
+    sqlite3 "$DB" "
+      UPDATE dispatches
+      SET status='reported',
+          reported_at=COALESCE(reported_at, strftime('%s','now')*1000),
+          report_text=COALESCE(report_text, 'force-closed by hive-resync')
+      WHERE status NOT IN ('reported', 'cancelled', 'failed');
+    "
+    echo "Marked $OPEN_COUNT dispatches as reported."
+elif [ "$APPLY" = true ]; then
+    echo "Nothing to fix - no non-terminal dispatches."
+fi
+
+if [ "$RESTART" = true ]; then
+    if [ -n "${HIVE_PID:-}" ]; then
+        echo "Killing Hive runtime (pid $HIVE_PID)..."
+        kill "$HIVE_PID"
+        echo
+        echo "Now restart the runtime, e.g.:"
+        echo "  cd ~/development/hive && pnpm dev:runtime"
+        echo "Then re-launch workers in the Hive UI."
+    else
+        echo "No Hive runtime process to kill."
+    fi
+fi
+
+if [ "$APPLY" = false ] && [ "$RESTART" = false ]; then
+    echo
+    echo "Dry run. Pass --fix to mark these as reported, --restart to kill the daemon."
+    echo "Typical recovery: hive-resync --fix --restart"
+fi

--- a/src/server/dispatch-ledger-store.ts
+++ b/src/server/dispatch-ledger-store.ts
@@ -158,7 +158,7 @@ export const createDispatchLedgerStore = (db: Database) => {
            WHERE id = ?
              AND workspace_id = ?
              AND to_agent_id = ?
-             AND status != 'reported'
+             AND status NOT IN ('reported', 'cancelled', 'failed')
            LIMIT 1`
         )
         .get(dispatchId, workspaceId, toAgentId) as DispatchRow | undefined
@@ -172,7 +172,7 @@ export const createDispatchLedgerStore = (db: Database) => {
          FROM dispatches
          WHERE workspace_id = ?
            AND to_agent_id = ?
-           AND status != 'reported'
+           AND status NOT IN ('reported', 'cancelled', 'failed')
          ORDER BY sequence ASC
          LIMIT 1`
       )
@@ -243,7 +243,7 @@ export const createDispatchLedgerStore = (db: Database) => {
       .prepare(
         `SELECT workspace_id, to_agent_id AS worker_id, 'send' AS type
            FROM dispatches
-           WHERE status != 'reported'
+           WHERE status NOT IN ('reported', 'cancelled', 'failed')
            ORDER BY sequence ASC`
       )
       .all() as Array<{ type: 'send'; worker_id: string; workspace_id: string }>

--- a/src/server/dispatch-ledger-store.ts
+++ b/src/server/dispatch-ledger-store.ts
@@ -51,10 +51,38 @@ interface ReportDispatchInput {
   workspaceId: string
 }
 
+const OPEN_FILTER = "status NOT IN ('reported', 'cancelled', 'failed')"
+
 export interface ListDispatchesOptions {
   limit?: number
   offset?: number
   status?: DispatchStatus
+}
+
+export const countOpenDispatchesByWorker = (db: Database, workspaceId: string) => {
+  return db
+    .prepare(
+      `SELECT to_agent_id AS worker_id, COUNT(*) AS open_count
+       FROM dispatches
+       WHERE workspace_id = ? AND ${OPEN_FILTER}
+       GROUP BY to_agent_id`
+    )
+    .all(workspaceId) as Array<{ open_count: number; worker_id: string }>
+}
+
+export const countOpenDispatchesForWorker = (
+  db: Database,
+  workspaceId: string,
+  workerId: string
+) => {
+  const row = db
+    .prepare(
+      `SELECT COUNT(*) AS open_count
+       FROM dispatches
+       WHERE workspace_id = ? AND to_agent_id = ? AND ${OPEN_FILTER}`
+    )
+    .get(workspaceId, workerId) as { open_count: number } | undefined
+  return row?.open_count ?? 0
 }
 
 const parseArtifacts = (value: string | null) => {
@@ -158,7 +186,7 @@ export const createDispatchLedgerStore = (db: Database) => {
            WHERE id = ?
              AND workspace_id = ?
              AND to_agent_id = ?
-             AND status NOT IN ('reported', 'cancelled', 'failed')
+             AND ${OPEN_FILTER}
            LIMIT 1`
         )
         .get(dispatchId, workspaceId, toAgentId) as DispatchRow | undefined
@@ -172,7 +200,7 @@ export const createDispatchLedgerStore = (db: Database) => {
          FROM dispatches
          WHERE workspace_id = ?
            AND to_agent_id = ?
-           AND status NOT IN ('reported', 'cancelled', 'failed')
+           AND ${OPEN_FILTER}
          ORDER BY sequence ASC
          LIMIT 1`
       )
@@ -243,7 +271,7 @@ export const createDispatchLedgerStore = (db: Database) => {
       .prepare(
         `SELECT workspace_id, to_agent_id AS worker_id, 'send' AS type
            FROM dispatches
-           WHERE status NOT IN ('reported', 'cancelled', 'failed')
+           WHERE ${OPEN_FILTER}
            ORDER BY sequence ASC`
       )
       .all() as Array<{ type: 'send'; worker_id: string; workspace_id: string }>

--- a/src/server/env-sync-message.ts
+++ b/src/server/env-sync-message.ts
@@ -1,4 +1,4 @@
-import type { AgentSummary, WorkspaceSummary } from '../shared/types.js'
+import type { AgentSummary, TeamListItem, WorkspaceSummary } from '../shared/types.js'
 
 import { getHiveTeamRules } from './hive-team-guidance.js'
 import type { RecoveryMessage } from './message-log-store.js'
@@ -7,7 +7,7 @@ import { TASKS_RELATIVE_PATH } from './tasks-file.js'
 
 const TASKS_HEAD_LIMIT = 1024
 
-const formatWorkers = (workers: AgentSummary[]) => {
+const formatWorkers = (workers: TeamListItem[]) => {
   if (workers.length === 0) return ['- 当前没有其他 worker']
   return workers.map(
     (worker) =>
@@ -34,7 +34,7 @@ export const buildEnvSyncMessage = ({
 }: {
   agent: AgentSummary
   tasksContent: string
-  workers: AgentSummary[]
+  workers: TeamListItem[]
   workspace: WorkspaceSummary
   restartWindowMessages: RecoveryMessage[]
 }) =>

--- a/src/server/recovery-summary.ts
+++ b/src/server/recovery-summary.ts
@@ -1,4 +1,4 @@
-import type { AgentSummary, WorkspaceSummary } from '../shared/types.js'
+import type { AgentSummary, TeamListItem, WorkspaceSummary } from '../shared/types.js'
 
 import { getHiveTeamRules } from './hive-team-guidance.js'
 import type { RecoveryMessage } from './message-log-store.js'
@@ -35,13 +35,13 @@ const formatTaskEvents = (messages: RecoveryMessage[], agent: AgentSummary) => {
     : ['- （最近没有任务事件）']
 }
 
-const getOpenTaskTargets = (agent: AgentSummary, workers: AgentSummary[]) =>
+const getOpenTaskTargets = (agent: AgentSummary, workers: TeamListItem[]) =>
   agent.role === 'orchestrator' ? workers : [agent]
 
 const formatOpenTasks = (
   messages: RecoveryMessage[],
   agent: AgentSummary,
-  workers: AgentSummary[]
+  workers: TeamListItem[]
 ) => {
   const targetAgents = getOpenTaskTargets(agent, workers).filter(
     (target) => target.role !== 'orchestrator'
@@ -78,7 +78,7 @@ const formatOpenTasks = (
   return lines.length > 0 ? lines : ['- （当前没有未完成任务）']
 }
 
-const formatWorkers = (workers: AgentSummary[]) => {
+const formatWorkers = (workers: TeamListItem[]) => {
   if (workers.length === 0) return ['- 当前没有其他 worker']
   return workers.map(
     (worker) =>
@@ -101,7 +101,7 @@ export const buildRecoverySummary = ({
   allTaskMessages?: RecoveryMessage[]
   messages: RecoveryMessage[]
   tasksContent: string
-  workers: AgentSummary[]
+  workers: TeamListItem[]
   workspace: WorkspaceSummary
 }) =>
   wrapSystemMessage(

--- a/src/server/restart-policy.ts
+++ b/src/server/restart-policy.ts
@@ -41,9 +41,15 @@ export const createRestartPolicy = ({
     const snapshot = getWorkspaceSnapshot(workspace.id)
     const agent = snapshot.agents.find((item) => item.id === agentId)
     if (!agent) return false
-    const workers = snapshot.agents.filter(
-      (item) => item.role !== 'orchestrator' && item.id !== agentId
-    )
+    const workers = snapshot.agents
+      .filter((item) => item.role !== 'orchestrator' && item.id !== agentId)
+      .map(({ id, name, pendingTaskCount, role, status }) => ({
+        id,
+        name,
+        pendingTaskCount,
+        role: role as Exclude<typeof role, 'orchestrator'>,
+        status,
+      }))
     const tasksContent = readTasks(snapshot.summary.path)
 
     if (startConfig.resumedSessionId) return true

--- a/src/server/runtime-store-helpers.ts
+++ b/src/server/runtime-store-helpers.ts
@@ -73,7 +73,7 @@ export const createRuntimeStoreServices = (
 
   agentRunStore.markUnfinishedRunsStale()
 
-  const workspaceStore = createWorkspaceStore(db, dispatchLedgerStore.listOpenDispatchKinds())
+  const workspaceStore = createWorkspaceStore(db)
   const startExistingWorkspaceWatches = () => {
     for (const workspace of workspaceStore.listWorkspaces()) {
       void tasksFileWatcher.start(workspace.id, workspace.path)

--- a/src/server/terminal-stream-hub.ts
+++ b/src/server/terminal-stream-hub.ts
@@ -181,7 +181,15 @@ export const createTerminalStreamHub = (store: RuntimeStore): TerminalStreamHub 
         },
       })
       socket.on('message', (raw) => {
-        store.writeRunInput(runId, raw.toString())
+        try {
+          store.writeRunInput(runId, raw.toString())
+        } catch (error) {
+          viewer.controlSocket?.send(
+            serializeTerminalError(
+              error instanceof Error ? error.message : 'Failed to write terminal input'
+            )
+          )
+        }
       })
       socket.on('close', () => {
         if (viewer.ioSocket === socket) viewer.ioSocket = null

--- a/src/server/workspace-store-hydration.ts
+++ b/src/server/workspace-store-hydration.ts
@@ -3,10 +3,7 @@ import type { AgentSummary } from '../shared/types.js'
 import { getDefaultRoleDescription } from './role-templates.js'
 import type { WorkspaceRecord } from './workspace-store-contract.js'
 import {
-  applyPendingTaskCount,
   createOrchestrator,
-  isWorkerAgent,
-  type MessageKindRecord,
   type WorkerRow,
   type WorkspaceRow,
   type WorkspaceSummaryRow,
@@ -25,31 +22,9 @@ const createWorkerSummary = (
   pendingTaskCount: 0,
 })
 
-const applyMessageKinds = (
-  workspaces: Map<string, WorkspaceRecord>,
-  messageKinds: MessageKindRecord[],
-  workspaceId?: string
-) => {
-  for (const row of messageKinds) {
-    if (workspaceId && row.workspace_id !== workspaceId) {
-      continue
-    }
-
-    const worker = workspaces
-      .get(row.workspace_id)
-      ?.agents.find((agent) => agent.id === row.worker_id)
-    if (!worker || !isWorkerAgent(worker)) {
-      continue
-    }
-
-    applyPendingTaskCount(worker, row.type, true)
-  }
-}
-
 export const hydrateWorkspaceFromDb = (
   db: Database,
   workspaces: Map<string, WorkspaceRecord>,
-  messageKinds: MessageKindRecord[],
   workspaceId: string
 ) => {
   if (workspaces.has(workspaceId)) {
@@ -75,15 +50,9 @@ export const hydrateWorkspaceFromDb = (
     .all(workspaceId) as WorkerRow[]) {
     workspaces.get(workspaceId)?.agents.push(createWorkerSummary(workerRow.workspace_id, workerRow))
   }
-
-  applyMessageKinds(workspaces, messageKinds, workspaceId)
 }
 
-export const seedWorkspacesFromDb = (
-  db: Database,
-  workspaces: Map<string, WorkspaceRecord>,
-  messageKinds: MessageKindRecord[]
-) => {
+export const seedWorkspacesFromDb = (db: Database, workspaces: Map<string, WorkspaceRecord>) => {
   for (const row of db
     .prepare('SELECT id, name, path FROM workspaces ORDER BY created_at ASC')
     .all() as WorkspaceRow[]) {
@@ -100,6 +69,4 @@ export const seedWorkspacesFromDb = (
     .all() as WorkerRow[]) {
     workspaces.get(row.workspace_id)?.agents.push(createWorkerSummary(row.workspace_id, row))
   }
-
-  applyMessageKinds(workspaces, messageKinds)
 }

--- a/src/server/workspace-store-mutations.ts
+++ b/src/server/workspace-store-mutations.ts
@@ -59,26 +59,17 @@ export const markAgentStopped = (
 }
 
 export const markTaskDispatched = (
-  workspaces: WorkspaceMap,
-  workspaceId: string,
-  workerId: string
+  _workspaces: WorkspaceMap,
+  _workspaceId: string,
+  _workerId: string
 ) => {
-  const worker = getWorkerRecord(workspaces, workspaceId, workerId)
-  worker.pendingTaskCount += 1
-  // spec §3.6.4: a stopped worker may accumulate queued tasks; PTY isn't
-  // running so it can't be `working`. Stay stopped until restart (mirrors
-  // markTaskReported's stopped guard below).
-  if (worker.status !== 'stopped')
-    worker.status = getStatusFromPendingCount(worker.pendingTaskCount)
+  console.warn('[hive] markTaskDispatched is deprecated; pending state is derived from dispatches')
 }
 
 export const markTaskReported = (
-  workspaces: WorkspaceMap,
-  workspaceId: string,
-  workerId: string
+  _workspaces: WorkspaceMap,
+  _workspaceId: string,
+  _workerId: string
 ) => {
-  const worker = getWorkerRecord(workspaces, workspaceId, workerId)
-  worker.pendingTaskCount = Math.max(0, worker.pendingTaskCount - 1)
-  if (worker.status !== 'stopped')
-    worker.status = getStatusFromPendingCount(worker.pendingTaskCount)
+  console.warn('[hive] markTaskReported is deprecated; pending state is derived from dispatches')
 }

--- a/src/server/workspace-store-support.ts
+++ b/src/server/workspace-store-support.ts
@@ -1,12 +1,6 @@
 import type { AgentStatus, AgentSummary, WorkerRole } from '../shared/types.js'
 import { getDefaultRoleDescription } from './role-templates.js'
 
-export interface MessageKindRecord {
-  type: 'send' | 'report'
-  worker_id: string
-  workspace_id: string
-}
-
 export interface WorkspaceRow {
   id: string
   name: string
@@ -43,16 +37,4 @@ export const isWorkerAgent = (
 
 export const getStatusFromPendingCount = (pendingTaskCount: number): AgentStatus => {
   return pendingTaskCount > 0 ? 'working' : 'idle'
-}
-
-export const applyPendingTaskCount = (
-  worker: AgentSummary & { role: WorkerRole },
-  type: MessageKindRecord['type'],
-  preserveStoppedStatus: boolean
-) => {
-  worker.pendingTaskCount =
-    type === 'send' ? worker.pendingTaskCount + 1 : Math.max(0, worker.pendingTaskCount - 1)
-  if (!preserveStoppedStatus) {
-    worker.status = getStatusFromPendingCount(worker.pendingTaskCount)
-  }
 }

--- a/src/server/workspace-store.ts
+++ b/src/server/workspace-store.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from 'node:crypto'
 import type { Database } from 'better-sqlite3'
 
-import type { AgentSummary } from '../shared/types.js'
+import type { AgentStatus, AgentSummary, TeamListItem } from '../shared/types.js'
+import {
+  countOpenDispatchesByWorker,
+  countOpenDispatchesForWorker,
+} from './dispatch-ledger-store.js'
 import { ConflictError } from './http-errors.js'
 import { getDefaultRoleDescription } from './role-templates.js'
 import type { WorkerInput, WorkspaceRecord, WorkspaceStore } from './workspace-store-contract.js'
@@ -15,13 +19,22 @@ import {
   markTaskDispatched,
   markTaskReported,
 } from './workspace-store-mutations.js'
-import {
-  createOrchestrator,
-  isWorkerAgent,
-  type MessageKindRecord,
-} from './workspace-store-support.js'
+import { createOrchestrator, isWorkerAgent } from './workspace-store-support.js'
 
 export type { WorkerInput, WorkspaceRecord, WorkspaceStore }
+
+const deriveWorkerStatus = (worker: AgentSummary, openCount: number): AgentStatus => {
+  if (worker.status === 'stopped') return 'stopped'
+  return openCount > 0 ? 'working' : 'idle'
+}
+
+const openDispatchCountMap = (db: Database, workspaceId: string) => {
+  const counts = new Map<string, number>()
+  for (const row of countOpenDispatchesByWorker(db, workspaceId)) {
+    counts.set(row.worker_id, row.open_count)
+  }
+  return counts
+}
 
 const normalizeWorkerName = (name: string) => {
   const trimmed = name.trim()
@@ -30,19 +43,31 @@ const normalizeWorkerName = (name: string) => {
   return trimmed
 }
 
-export const createWorkspaceStore = (
-  db: Database,
-  messageKinds: MessageKindRecord[]
-): WorkspaceStore => {
+export const createWorkspaceStore = (db: Database): WorkspaceStore => {
   const workspaces = new Map<string, WorkspaceRecord>()
-  seedWorkspacesFromDb(db, workspaces, messageKinds)
+  seedWorkspacesFromDb(db, workspaces)
 
   const getWorkspace = (workspaceId: string) => {
-    hydrateWorkspaceFromDb(db, workspaces, messageKinds, workspaceId)
+    hydrateWorkspaceFromDb(db, workspaces, workspaceId)
     const workspace = workspaces.get(workspaceId)
     if (!workspace) throw new Error(`Workspace not found: ${workspaceId}`)
     return workspace
   }
+
+  const decorateAgent = (workspaceId: string, agent: AgentSummary): AgentSummary => {
+    if (!isWorkerAgent(agent)) return agent
+    const pendingTaskCount = countOpenDispatchesForWorker(db, workspaceId, agent.id)
+    return {
+      ...agent,
+      pendingTaskCount,
+      status: deriveWorkerStatus(agent, pendingTaskCount),
+    }
+  }
+
+  const decorateWorkspace = (workspace: WorkspaceRecord): WorkspaceRecord => ({
+    summary: workspace.summary,
+    agents: workspace.agents.map((agent) => decorateAgent(workspace.summary.id, agent)),
+  })
 
   return {
     addWorker(workspaceId, input) {
@@ -135,25 +160,37 @@ export const createWorkspaceStore = (
       })()
       workspace.agents = workspace.agents.filter((agent) => agent.id !== workerId)
     },
-    getAgent: (workspaceId, agentId) => getAgentRecord(workspaces, workspaceId, agentId),
-    getWorker: (workspaceId, workerId) => getWorkerRecord(workspaces, workspaceId, workerId),
-    getWorkerByName: (workspaceId, workerName) =>
-      getWorkerByNameRecord(workspaces, workspaceId, workerName),
-    getWorkspaceSnapshot: getWorkspace,
+    getAgent(workspaceId, agentId) {
+      getWorkspace(workspaceId)
+      return decorateAgent(workspaceId, getAgentRecord(workspaces, workspaceId, agentId))
+    },
+    getWorker(workspaceId, workerId) {
+      getWorkspace(workspaceId)
+      return decorateAgent(workspaceId, getWorkerRecord(workspaces, workspaceId, workerId))
+    },
+    getWorkerByName(workspaceId, workerName) {
+      getWorkspace(workspaceId)
+      return decorateAgent(workspaceId, getWorkerByNameRecord(workspaces, workspaceId, workerName))
+    },
+    getWorkspaceSnapshot: (workspaceId) => decorateWorkspace(getWorkspace(workspaceId)),
     hasAgent(workspaceId, agentId) {
-      hydrateWorkspaceFromDb(db, workspaces, messageKinds, workspaceId)
+      hydrateWorkspaceFromDb(db, workspaces, workspaceId)
       return workspaces.get(workspaceId)?.agents.some((agent) => agent.id === agentId) ?? false
     },
     listWorkers(workspaceId) {
+      const counts = openDispatchCountMap(db, workspaceId)
       return getWorkspace(workspaceId)
         .agents.filter(isWorkerAgent)
-        .map(({ id, name, role, status, pendingTaskCount }) => ({
-          id,
-          name,
-          role,
-          status,
-          pendingTaskCount,
-        }))
+        .map((worker): TeamListItem => {
+          const pendingTaskCount = counts.get(worker.id) ?? 0
+          return {
+            id: worker.id,
+            name: worker.name,
+            role: worker.role,
+            status: deriveWorkerStatus(worker, pendingTaskCount),
+            pendingTaskCount,
+          }
+        })
     },
     listWorkspaces() {
       return Array.from(workspaces.values(), (workspace) => workspace.summary)

--- a/tests/server/app.test.ts
+++ b/tests/server/app.test.ts
@@ -189,8 +189,6 @@ describe('runtime http app', () => {
       name: 'Alice',
       role: 'coder',
     })
-    // Simulate PTY already running so dispatchTask can promote to working.
-    store.getWorker(workspace.id, worker.id).status = 'idle'
     store.dispatchTask(workspace.id, worker.id, 'Implement feature')
 
     const sessionResponse = await fetch(`${baseUrl}/api/ui/session`)
@@ -209,7 +207,7 @@ describe('runtime http app', () => {
         id: worker.id,
         name: 'Alice',
         role: 'coder',
-        status: 'working',
+        status: 'stopped',
         pending_task_count: 1,
         last_pty_line: null,
         command_preset_id: null,

--- a/tests/server/dispatch-ledger-store.test.ts
+++ b/tests/server/dispatch-ledger-store.test.ts
@@ -1,0 +1,56 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import Database from 'better-sqlite3'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { createDispatchLedgerStore } from '../../src/server/dispatch-ledger-store.js'
+import { initializeRuntimeDatabase } from '../../src/server/sqlite-schema.js'
+
+const tempDirs: string[] = []
+
+const createStore = () => {
+  const dataDir = mkdtempSync(join(tmpdir(), 'hive-dispatch-ledger-'))
+  tempDirs.push(dataDir)
+  const db = new Database(join(dataDir, 'runtime.sqlite'))
+  initializeRuntimeDatabase(db)
+  return { db, store: createDispatchLedgerStore(db) }
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { force: true, recursive: true })
+})
+
+describe('dispatch ledger store', () => {
+  test('does not treat cancelled or failed dispatches as open work', () => {
+    const { db, store } = createStore()
+    const cancelled = store.createDispatch({
+      text: 'cancelled task',
+      toAgentId: 'worker-a',
+      workspaceId: 'workspace-a',
+    })
+    const failed = store.createDispatch({
+      text: 'failed task',
+      toAgentId: 'worker-a',
+      workspaceId: 'workspace-a',
+    })
+    const queued = store.createDispatch({
+      text: 'queued task',
+      toAgentId: 'worker-a',
+      workspaceId: 'workspace-a',
+    })
+
+    db.prepare("UPDATE dispatches SET status = 'cancelled' WHERE id = ?").run(cancelled.id)
+    db.prepare("UPDATE dispatches SET status = 'failed' WHERE id = ?").run(failed.id)
+
+    expect(store.findOpenDispatch('workspace-a', 'worker-a', cancelled.id)).toBeUndefined()
+    expect(store.findOpenDispatch('workspace-a', 'worker-a', failed.id)).toBeUndefined()
+    expect(store.findOpenDispatch('workspace-a', 'worker-a')?.id).toBe(queued.id)
+    expect(store.listOpenDispatchKinds()).toEqual([
+      { type: 'send', worker_id: 'worker-a', workspace_id: 'workspace-a' },
+    ])
+
+    db.close()
+  })
+})

--- a/tests/server/lifecycle-hardening.test.ts
+++ b/tests/server/lifecycle-hardening.test.ts
@@ -185,7 +185,7 @@ describe('lifecycle hardening (R2.1 / R2.2 / R2.3) — real PTY', () => {
     const { dataDir, workspacePath } = prepareWorkspace()
     const db = new Database(join(dataDir, 'runtime.sqlite'))
     initializeRuntimeDatabase(db)
-    const workspaceStore = createWorkspaceStore(db, [])
+    const workspaceStore = createWorkspaceStore(db)
     const workspace = workspaceStore.createWorkspace(workspacePath, 'Alpha')
     const worker = workspaceStore.addWorker(workspace.id, { name: 'Alice', role: 'coder' })
     const startedAt = Date.now() - 60_000
@@ -257,7 +257,7 @@ describe('lifecycle hardening (R2.1 / R2.2 / R2.3) — real PTY', () => {
 
     const db = new Database(join(dataDir, 'runtime.sqlite'))
     initializeRuntimeDatabase(db)
-    const workspaceStore = createWorkspaceStore(db, [])
+    const workspaceStore = createWorkspaceStore(db)
     const agentRunStore = createAgentRunStore(db)
     const onAgentExitSpy = vi.fn((workspaceId: string, agentId: string) => {
       workspaceStore.markAgentStopped(workspaceId, agentId)

--- a/tests/server/report-pending-count.test.ts
+++ b/tests/server/report-pending-count.test.ts
@@ -7,9 +7,6 @@ describe('report pending count', () => {
     const store = createRuntimeStore()
     const workspace = store.createWorkspace('/tmp/hive-alpha', 'Alpha')
     const worker = store.addWorker(workspace.id, { name: 'Alice', role: 'coder' })
-    // Simulate PTY started before dispatching.
-    store.getWorker(workspace.id, worker.id).status = 'idle'
-
     store.dispatchTask(workspace.id, worker.id, 'Task 1')
     store.dispatchTask(workspace.id, worker.id, 'Task 2')
     store.reportTask(workspace.id, worker.id, { status: 'success', text: 'Done one' })
@@ -18,7 +15,7 @@ describe('report pending count', () => {
       expect.objectContaining({
         id: worker.id,
         pendingTaskCount: 1,
-        status: 'working',
+        status: 'stopped',
       })
     )
   })

--- a/tests/server/runtime-store.test.ts
+++ b/tests/server/runtime-store.test.ts
@@ -76,7 +76,7 @@ describe('runtime store', () => {
     tempDirs.push(dataDir)
     const db = new Database(join(dataDir, 'runtime.sqlite'))
     initializeRuntimeDatabase(db)
-    const workspaceStore = createWorkspaceStore(db, [])
+    const workspaceStore = createWorkspaceStore(db)
     const originalPrepare = db.prepare.bind(db)
     vi.spyOn(db, 'prepare').mockImplementation((source: string) => {
       if (source.startsWith('INSERT INTO workspaces')) {
@@ -126,27 +126,25 @@ describe('runtime store', () => {
     })
   })
 
-  test('dispatchTask increments worker pending count and marks it working', () => {
-    const store = createRuntimeStore()
+  test('dispatchTask increments worker pending count and marks it working', async () => {
+    const store = createRuntimeStore({ agentManager: createFakeAgentManager() })
 
     const workspace = store.createWorkspace('/tmp/hive-alpha', 'Alpha')
     const worker = store.addWorker(workspace.id, {
       name: 'Alice',
       role: 'coder',
     })
-    // Simulate PTY started: worker is idle, not stopped (spec §3.6.4 keeps
-    // stopped workers from being silently promoted to working when their
-    // PTY isn't actually running).
-    store.getWorker(workspace.id, worker.id).status = 'idle'
+    store.configureAgentLaunch(workspace.id, worker.id, { command: '/bin/bash', args: [] })
+    await store.startAgent(workspace.id, worker.id, { hivePort: '4010' })
 
-    store.dispatchTask(workspace.id, worker.id, 'Implement feature')
+    await store.dispatchTask(workspace.id, worker.id, 'Implement feature')
 
     const updatedWorker = store.getWorker(workspace.id, worker.id)
     expect(updatedWorker.pendingTaskCount).toBe(1)
     expect(updatedWorker.status).toBe('working')
   })
 
-  test('dispatchTask keeps a stopped worker stopped while accumulating queue', () => {
+  test('dispatchTask keeps a stopped worker stopped while accumulating queue', async () => {
     const store = createRuntimeStore()
 
     const workspace = store.createWorkspace('/tmp/hive-alpha', 'Alpha')
@@ -156,7 +154,7 @@ describe('runtime store', () => {
     })
     // worker.addWorker initialises status='stopped' (PTY hasn't started).
 
-    store.dispatchTask(workspace.id, worker.id, 'Implement feature')
+    await store.dispatchTask(workspace.id, worker.id, 'Implement feature')
 
     const updatedWorker = store.getWorker(workspace.id, worker.id)
     expect(updatedWorker.pendingTaskCount).toBe(1)
@@ -184,9 +182,7 @@ describe('runtime store', () => {
       name: 'Alice',
       role: 'coder',
     })
-    // Simulate the worker already having an active PTY before queuing.
-    store.getWorker(workspace.id, worker.id).status = 'idle'
-    store.dispatchTask(workspace.id, worker.id, 'Implement feature')
+    await store.dispatchTask(workspace.id, worker.id, 'Implement feature')
     store.configureAgentLaunch(workspace.id, worker.id, { command: '/bin/bash', args: [] })
 
     await store.startAgent(workspace.id, worker.id, { hivePort: '4010' })
@@ -194,18 +190,18 @@ describe('runtime store', () => {
     expect(store.getWorker(workspace.id, worker.id).status).toBe('working')
   })
 
-  test('reportTask resets worker pending count and returns it to idle', () => {
-    const store = createRuntimeStore()
+  test('reportTask resets worker pending count and returns it to idle', async () => {
+    const store = createRuntimeStore({ agentManager: createFakeAgentManager() })
 
     const workspace = store.createWorkspace('/tmp/hive-alpha', 'Alpha')
     const worker = store.addWorker(workspace.id, {
       name: 'Alice',
       role: 'coder',
     })
-    // Simulate PTY already running so dispatchTask can promote to working.
-    store.getWorker(workspace.id, worker.id).status = 'idle'
+    store.configureAgentLaunch(workspace.id, worker.id, { command: '/bin/bash', args: [] })
+    await store.startAgent(workspace.id, worker.id, { hivePort: '4010' })
 
-    store.dispatchTask(workspace.id, worker.id, 'Implement feature')
+    await store.dispatchTask(workspace.id, worker.id, 'Implement feature')
     store.reportTask(workspace.id, worker.id, { status: 'success', text: 'Done' })
 
     const updatedWorker = store.getWorker(workspace.id, worker.id)
@@ -213,7 +209,7 @@ describe('runtime store', () => {
     expect(updatedWorker.status).toBe('idle')
   })
 
-  test('reportTask keeps a stopped worker stopped while draining pending count', () => {
+  test('reportTask keeps a stopped worker stopped while draining pending count', async () => {
     const store = createRuntimeStore()
 
     const workspace = store.createWorkspace('/tmp/hive-alpha', 'Alpha')
@@ -222,7 +218,7 @@ describe('runtime store', () => {
       role: 'coder',
     })
 
-    store.dispatchTask(workspace.id, worker.id, 'Implement feature')
+    await store.dispatchTask(workspace.id, worker.id, 'Implement feature')
     store.getWorker(workspace.id, worker.id).status = 'stopped'
     store.reportTask(workspace.id, worker.id, { status: 'success', text: 'Done' })
 
@@ -314,7 +310,7 @@ describe('runtime store', () => {
     tempDirs.push(dataDir)
     const db = new Database(join(dataDir, 'runtime.sqlite'))
     initializeRuntimeDatabase(db)
-    const workspaceStore = createWorkspaceStore(db, [])
+    const workspaceStore = createWorkspaceStore(db)
     const workspace = workspaceStore.createWorkspace('/tmp/hive-alpha', 'Alpha')
     const originalPrepare = db.prepare.bind(db)
     vi.spyOn(db, 'prepare').mockImplementation((source: string) => {

--- a/tests/unit/team-atomicity.test.ts
+++ b/tests/unit/team-atomicity.test.ts
@@ -202,9 +202,6 @@ describe('team atomicity', () => {
     const store = createRuntimeStore()
     const workspace = store.createWorkspace('/tmp/hive-alpha', 'Alpha')
     const worker = store.addWorker(workspace.id, { name: 'Alice', role: 'coder' })
-    // Simulate PTY already running so dispatchTask can promote to working.
-    store.getWorker(workspace.id, worker.id).status = 'idle'
-
     // Dispatch first so pendingTaskCount rises to 1 — gives reportTask something to decrement.
     store.dispatchTask(workspace.id, worker.id, 'Implement login')
     expect(store.listDispatches(workspace.id)).toContainEqual(
@@ -228,7 +225,7 @@ describe('team atomicity', () => {
       expect.objectContaining({
         id: worker.id,
         pendingTaskCount: 1,
-        status: 'working',
+        status: 'stopped',
       })
     )
     expect(store.listMessagesForRecovery(workspace.id, 0).length).toBe(beforeMessages)


### PR DESCRIPTION
Description

  ## Summary

  - Treat `cancelled` and `failed` dispatches as terminal states when looking for open work.
  - Add a targeted dispatch ledger test covering cancelled/failed rows.
  - Add `scripts/hive-resync.sh` for diagnosing and recovering stuck runtime dispatches.

  ## Tests

  - `pnpm exec vitest run tests/server/dispatch-ledger-store.test.ts tests/server/runtime-store.test.ts --no-file-parallelism --maxWorkers=1`
  - `pnpm exec biome check src/server/dispatch-ledger-store.ts tests/server/dispatch-ledger-store.test.ts scripts/hive-resync.sh`