### PR TITLE
feat: add DB schema migrations v20-v29

### DIFF
--- a/src/server/sqlite-schema-v20.ts
+++ b/src/server/sqlite-schema-v20.ts
@@ -1,0 +1,56 @@
+import type { Database } from 'better-sqlite3'
+
+export const applySchemaVersion20 = (db: Database) => {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS discussion_groups (
+      id TEXT PRIMARY KEY,
+      workspace_id TEXT NOT NULL,
+      topic TEXT NOT NULL,
+      max_rounds INTEGER NOT NULL DEFAULT 3,
+      current_round INTEGER NOT NULL DEFAULT 0,
+      max_messages INTEGER NOT NULL DEFAULT 20,
+      message_count INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL CHECK (status IN ('thinking','discussing','concluding','concluded','cancelled')),
+      listen_mode TEXT NOT NULL DEFAULT 'db',
+      created_by TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      concluded_at INTEGER
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_discussion_groups_workspace
+      ON discussion_groups (workspace_id, status);
+
+    CREATE TABLE IF NOT EXISTS discussion_members (
+      group_id TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      agent_name TEXT NOT NULL,
+      member_status TEXT NOT NULL DEFAULT 'invited'
+        CHECK (member_status IN ('invited','initial_submitted','active','round_submitted','skipped','final_submitted','failed')),
+      initial_position TEXT,
+      final_position TEXT,
+      rounds_participated INTEGER NOT NULL DEFAULT 0,
+      last_message_at INTEGER,
+      PRIMARY KEY (group_id, agent_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS discussion_messages (
+      sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+      group_id TEXT NOT NULL,
+      round INTEGER NOT NULL,
+      from_agent_id TEXT NOT NULL,
+      message_type TEXT NOT NULL CHECK (message_type IN ('initial','discuss','conclude')),
+      text TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_discussion_messages_group_round
+      ON discussion_messages (group_id, round, sequence);
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_discussion_messages_one_per_round
+      ON discussion_messages (group_id, round, from_agent_id)
+      WHERE message_type = 'discuss';
+
+    CREATE INDEX IF NOT EXISTS idx_discussion_members_active_agent
+      ON discussion_members (agent_id, group_id);
+  `)
+}

--- a/src/server/sqlite-schema-v21.ts
+++ b/src/server/sqlite-schema-v21.ts
@@ -1,0 +1,29 @@
+import type { Database } from 'better-sqlite3'
+
+export const applySchemaVersion21 = (db: Database) => {
+  db.exec(`
+    CREATE TABLE discussion_messages_new (
+      sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+      group_id TEXT NOT NULL,
+      round INTEGER NOT NULL,
+      from_agent_id TEXT NOT NULL,
+      message_type TEXT NOT NULL CHECK (message_type IN ('initial','discuss','conclude','system')),
+      text TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+
+    INSERT INTO discussion_messages_new (sequence, group_id, round, from_agent_id, message_type, text, created_at)
+      SELECT sequence, group_id, round, from_agent_id, message_type, text, created_at FROM discussion_messages;
+
+    DROP TABLE discussion_messages;
+
+    ALTER TABLE discussion_messages_new RENAME TO discussion_messages;
+
+    CREATE INDEX IF NOT EXISTS idx_discussion_messages_group_round
+      ON discussion_messages (group_id, round, sequence);
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_discussion_messages_one_per_round
+      ON discussion_messages (group_id, round, from_agent_id)
+      WHERE message_type = 'discuss';
+  `)
+}

--- a/src/server/sqlite-schema-v22.ts
+++ b/src/server/sqlite-schema-v22.ts
@@ -1,0 +1,9 @@
+import type { Database } from 'better-sqlite3'
+
+export const applySchemaVersion22 = (db: Database) => {
+  db.exec(`
+    ALTER TABLE discussion_groups ADD COLUMN orch_participates INTEGER NOT NULL DEFAULT 0;
+
+    ALTER TABLE discussion_members ADD COLUMN role TEXT NOT NULL DEFAULT 'worker';
+  `)
+}

--- a/src/server/sqlite-schema-v23.ts
+++ b/src/server/sqlite-schema-v23.ts
@@ -1,0 +1,7 @@
+import type { Database } from 'better-sqlite3'
+
+export const applySchemaVersion23 = (db: Database) => {
+  db.exec(`
+    ALTER TABLE role_templates ADD COLUMN discussion_triggers TEXT;
+  `)
+}

--- a/src/server/sqlite-schema-v24.ts
+++ b/src/server/sqlite-schema-v24.ts
@@ -1,0 +1,53 @@
+import type { Database } from 'better-sqlite3'
+
+export const applySchemaVersion24 = (db: Database) => {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS tasks (
+      id TEXT PRIMARY KEY,
+      workspace_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'open',
+      source TEXT,
+      source_ref TEXT,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_tasks_workspace ON tasks (workspace_id, status);
+
+    CREATE TABLE IF NOT EXISTS task_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      workspace_id TEXT NOT NULL,
+      task_id TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      agent_id TEXT,
+      dispatch_id TEXT,
+      payload TEXT,
+      line_snapshot TEXT,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_task_events_task ON task_events (task_id, created_at);
+
+    CREATE TABLE IF NOT EXISTS discussion_sync_log (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      member_id TEXT NOT NULL,
+      group_id TEXT NOT NULL,
+      phase_key TEXT NOT NULL,
+      agent_run_id TEXT,
+      sync_kind TEXT NOT NULL,
+      attempted_at INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_discussion_sync_log_member
+      ON discussion_sync_log (member_id, group_id);
+  `)
+
+  const columns = new Set(
+    (db.prepare('PRAGMA table_info(dispatches)').all() as Array<{ name: string }>).map(
+      (col) => col.name
+    )
+  )
+  if (!columns.has('task_id')) {
+    db.exec('ALTER TABLE dispatches ADD COLUMN task_id TEXT')
+  }
+}

--- a/src/server/sqlite-schema-v25.ts
+++ b/src/server/sqlite-schema-v25.ts
@@ -1,0 +1,15 @@
+import type { Database } from 'better-sqlite3'
+
+export const applySchemaVersion25 = (db: Database) => {
+  const columns = new Set(
+    (db.prepare('PRAGMA table_info(role_templates)').all() as Array<{ name: string }>).map(
+      (col) => col.name
+    )
+  )
+  if (!columns.has('suggested_name')) {
+    db.exec('ALTER TABLE role_templates ADD COLUMN suggested_name TEXT')
+  }
+  if (!columns.has('command_preset_id')) {
+    db.exec('ALTER TABLE role_templates ADD COLUMN command_preset_id TEXT')
+  }
+}

--- a/src/server/sqlite-schema-v26.ts
+++ b/src/server/sqlite-schema-v26.ts
@@ -1,0 +1,26 @@
+import type { Database } from 'better-sqlite3'
+
+export const applySchemaVersion26 = (db: Database) => {
+  const wsColumns = new Set(
+    (db.prepare('PRAGMA table_info(workspaces)').all() as Array<{ name: string }>).map(
+      (col) => col.name
+    )
+  )
+  if (!wsColumns.has('sort_order')) {
+    db.exec('ALTER TABLE workspaces ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0')
+    const rows = db.prepare('SELECT id FROM workspaces ORDER BY created_at ASC').all() as Array<{
+      id: string
+    }>
+    const stmt = db.prepare('UPDATE workspaces SET sort_order = ? WHERE id = ?')
+    rows.forEach((row, i) => stmt.run(i, row.id))
+  }
+
+  const rtColumns = new Set(
+    (db.prepare('PRAGMA table_info(role_templates)').all() as Array<{ name: string }>).map(
+      (col) => col.name
+    )
+  )
+  if (!rtColumns.has('use_count')) {
+    db.exec('ALTER TABLE role_templates ADD COLUMN use_count INTEGER NOT NULL DEFAULT 0')
+  }
+}

--- a/src/server/sqlite-schema-v27.ts
+++ b/src/server/sqlite-schema-v27.ts
@@ -1,0 +1,26 @@
+import type { Database } from 'better-sqlite3'
+
+export const applySchemaVersion27 = (db: Database) => {
+  const columns = new Set(
+    (db.prepare('PRAGMA table_info(tasks)').all() as Array<{ name: string }>).map(
+      (col) => col.name
+    )
+  )
+  if (!columns.has('seq')) {
+    db.exec('ALTER TABLE tasks ADD COLUMN seq INTEGER')
+
+    const rows = db
+      .prepare('SELECT id, workspace_id FROM tasks ORDER BY workspace_id, created_at ASC')
+      .all() as Array<{ id: string; workspace_id: string }>
+
+    const counters = new Map<string, number>()
+    const stmt = db.prepare('UPDATE tasks SET seq = ? WHERE id = ?')
+    for (const row of rows) {
+      const next = (counters.get(row.workspace_id) ?? 0) + 1
+      counters.set(row.workspace_id, next)
+      stmt.run(next, row.id)
+    }
+
+    db.exec('CREATE UNIQUE INDEX idx_tasks_workspace_seq ON tasks (workspace_id, seq)')
+  }
+}

--- a/src/server/sqlite-schema-v28.ts
+++ b/src/server/sqlite-schema-v28.ts
@@ -1,0 +1,12 @@
+import type { Database } from 'better-sqlite3'
+
+export const applySchemaVersion28 = (db: Database) => {
+  const columns = new Set(
+    (db.prepare('PRAGMA table_info(agent_runs)').all() as Array<{ name: string }>).map(
+      (col) => col.name
+    )
+  )
+  if (!columns.has('checkpoint_json')) {
+    db.exec('ALTER TABLE agent_runs ADD COLUMN checkpoint_json TEXT')
+  }
+}

--- a/src/server/sqlite-schema-v29.ts
+++ b/src/server/sqlite-schema-v29.ts
@@ -1,0 +1,12 @@
+import type { Database } from 'better-sqlite3'
+
+export const applySchemaVersion29 = (db: Database) => {
+  const columns = new Set(
+    (db.prepare('PRAGMA table_info(agent_runs)').all() as Array<{ name: string }>).map(
+      (col) => col.name
+    )
+  )
+  if (!columns.has('tmux_session')) {
+    db.exec('ALTER TABLE agent_runs ADD COLUMN tmux_session TEXT')
+  }
+}

--- a/src/server/sqlite-schema.ts
+++ b/src/server/sqlite-schema.ts
@@ -13,8 +13,19 @@ import { applySchemaVersion15 } from './sqlite-schema-v15.js'
 import { applySchemaVersion16 } from './sqlite-schema-v16.js'
 import { applySchemaVersion17 } from './sqlite-schema-v17.js'
 import { applySchemaVersion18 } from './sqlite-schema-v18.js'
+import { applySchemaVersion19 } from './sqlite-schema-v19.js'
+import { applySchemaVersion20 } from './sqlite-schema-v20.js'
+import { applySchemaVersion21 } from './sqlite-schema-v21.js'
+import { applySchemaVersion22 } from './sqlite-schema-v22.js'
+import { applySchemaVersion23 } from './sqlite-schema-v23.js'
+import { applySchemaVersion24 } from './sqlite-schema-v24.js'
+import { applySchemaVersion25 } from './sqlite-schema-v25.js'
+import { applySchemaVersion26 } from './sqlite-schema-v26.js'
+import { applySchemaVersion27 } from './sqlite-schema-v27.js'
+import { applySchemaVersion28 } from './sqlite-schema-v28.js'
+import { applySchemaVersion29 } from './sqlite-schema-v29.js'
 
-export const CURRENT_SCHEMA_VERSION = 18
+export const CURRENT_SCHEMA_VERSION = 29
 
 export const initializeRuntimeDatabase = (db: Database) => {
   db.exec(`
@@ -244,5 +255,60 @@ export const initializeRuntimeDatabase = (db: Database) => {
   if (!appliedVersions.has(18)) {
     applySchemaVersion18(db)
     db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(18, Date.now())
+  }
+
+  if (!appliedVersions.has(19)) {
+    applySchemaVersion19(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(19, Date.now())
+  }
+
+  if (!appliedVersions.has(20)) {
+    applySchemaVersion20(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(20, Date.now())
+  }
+
+  if (!appliedVersions.has(21)) {
+    applySchemaVersion21(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(21, Date.now())
+  }
+
+  if (!appliedVersions.has(22)) {
+    applySchemaVersion22(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(22, Date.now())
+  }
+
+  if (!appliedVersions.has(23)) {
+    applySchemaVersion23(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(23, Date.now())
+  }
+
+  if (!appliedVersions.has(24)) {
+    applySchemaVersion24(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(24, Date.now())
+  }
+
+  if (!appliedVersions.has(25)) {
+    applySchemaVersion25(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(25, Date.now())
+  }
+
+  if (!appliedVersions.has(26)) {
+    applySchemaVersion26(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(26, Date.now())
+  }
+
+  if (!appliedVersions.has(27)) {
+    applySchemaVersion27(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(27, Date.now())
+  }
+
+  if (!appliedVersions.has(28)) {
+    applySchemaVersion28(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(28, Date.now())
+  }
+
+  if (!appliedVersions.has(29)) {
+    applySchemaVersion29(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(29, Date.now())
   }
 }

--- a/tests/server/schema-version.test.ts
+++ b/tests/server/schema-version.test.ts
@@ -18,7 +18,7 @@ afterEach(async () => {
   }
 })
 
-const expectDispatchSchema = (db: Database) => {
+const expectDispatchSchema = (db: InstanceType<typeof Database>) => {
   const dispatchTable = db
     .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'dispatches'")
     .get() as { name: string } | undefined
@@ -33,7 +33,7 @@ const expectDispatchSchema = (db: Database) => {
   expect(dispatchIndexes.has('idx_dispatches_open_by_worker')).toBe(true)
 }
 
-const indexColumns = (db: Database, indexName: string) =>
+const indexColumns = (db: InstanceType<typeof Database>, indexName: string) =>
   (db.prepare(`PRAGMA index_info(${indexName})`).all() as Array<{ name: string }>).map(
     (column) => column.name
   )
@@ -137,6 +137,7 @@ describe('schema version', () => {
         'is_builtin',
         'created_at',
         'updated_at',
+        'discussion_triggers',
       ])
     )
     expect(appStateColumns).toEqual(new Set(['key', 'value', 'updated_at']))
@@ -156,6 +157,7 @@ describe('schema version', () => {
         'reported_at',
         'report_text',
         'artifacts',
+        'task_id',
       ])
     )
     expectDispatchSchema(db)
@@ -190,6 +192,19 @@ describe('schema version', () => {
 
       INSERT INTO schema_version (version, applied_at)
       VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8);
+
+      CREATE TABLE role_templates (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        role_type TEXT NOT NULL,
+        description TEXT NOT NULL,
+        default_command TEXT NOT NULL,
+        default_args TEXT NOT NULL,
+        default_env TEXT NOT NULL,
+        is_builtin INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
 
       CREATE TABLE command_presets (
         id TEXT PRIMARY KEY,
@@ -265,6 +280,19 @@ describe('schema version', () => {
 
       INSERT INTO schema_version (version, applied_at)
       VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9);
+
+      CREATE TABLE role_templates (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        role_type TEXT NOT NULL,
+        description TEXT NOT NULL,
+        default_command TEXT NOT NULL,
+        default_args TEXT NOT NULL,
+        default_env TEXT NOT NULL,
+        is_builtin INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
 
       CREATE TABLE command_presets (
         id TEXT PRIMARY KEY,
@@ -376,6 +404,19 @@ describe('schema version', () => {
       INSERT INTO schema_version (version, applied_at)
       VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10);
 
+      CREATE TABLE role_templates (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        role_type TEXT NOT NULL,
+        description TEXT NOT NULL,
+        default_command TEXT NOT NULL,
+        default_args TEXT NOT NULL,
+        default_env TEXT NOT NULL,
+        is_builtin INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+
       CREATE TABLE command_presets (
         id TEXT PRIMARY KEY,
         display_name TEXT NOT NULL,
@@ -451,6 +492,19 @@ describe('schema version', () => {
 
       INSERT INTO schema_version (version, applied_at)
       VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10), (11, 11), (12, 12), (13, 13), (14, 14), (15, 15), (16, 16);
+
+      CREATE TABLE role_templates (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        role_type TEXT NOT NULL,
+        description TEXT NOT NULL,
+        default_command TEXT NOT NULL,
+        default_args TEXT NOT NULL,
+        default_env TEXT NOT NULL,
+        is_builtin INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
 
       CREATE TABLE command_presets (
         id TEXT PRIMARY KEY,
@@ -712,6 +766,19 @@ describe('schema version', () => {
       INSERT INTO schema_version (version, applied_at)
       VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10), (11, 11), (12, 12), (13, 13);
 
+      CREATE TABLE role_templates (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        role_type TEXT NOT NULL,
+        description TEXT NOT NULL,
+        default_command TEXT NOT NULL,
+        default_args TEXT NOT NULL,
+        default_env TEXT NOT NULL,
+        is_builtin INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+
       CREATE TABLE messages (
         sequence INTEGER PRIMARY KEY AUTOINCREMENT,
         workspace_id TEXT NOT NULL,
@@ -809,6 +876,19 @@ describe('schema version', () => {
 
       INSERT INTO schema_version (version, applied_at)
       VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10), (11, 11), (12, 12), (13, 13), (14, 14);
+
+      CREATE TABLE role_templates (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        role_type TEXT NOT NULL,
+        description TEXT NOT NULL,
+        default_command TEXT NOT NULL,
+        default_args TEXT NOT NULL,
+        default_env TEXT NOT NULL,
+        is_builtin INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
 
       CREATE TABLE dispatches (
         id TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary
Add database schema migration files v20-v29 for new features (discussion mode, recovery, etc.)

## Stack Order: 1/6
This is the **first** PR in a stacked series. Merge this first.

**Stack:**
1. **→ This PR** — DB schema migrations
2. feat/discussion-mode — Multi-round discussion mode
3. feat/recovery-hardening — Restart recovery hardening
4. feat/role-template-redesign — Role template redesign + worker dialog UX
5. feat/ui-overhaul — Phase 4 UI overhaul
6. feat/core-infrastructure — Core infrastructure updates

## Changes
- 10 new migration files (sqlite-schema-v20 through v29)
- Updated main schema registry
- Schema version test