### PR TITLE
feat: multi-round discussion mode with crash recovery

### DIFF
--- a/docs/specs/2026-05-24-discussion-mode.md
+++ b/docs/specs/2026-05-24-discussion-mode.md
@@ -1,0 +1,348 @@
+# Hive Discussion Mode — Worker 间直接通信设计 (v2)
+
+> 状态：Approved  
+> 日期：2026-05-24  
+> 灵感来源：HeavySkill: Heavy Thinking as the Inner Skill in Agentic Harness (ICML 2026, arXiv:2605.02396)  
+> 评审：米芾（后端）、莫邪（前端）、韩愈（架构）
+
+## 1. 动机
+
+当前 Hive 的通信模型是星形：Worker 只能通过 `team report` 向 Orchestrator 汇报，Worker 之间完全隔离。这适合**分治**场景，但不适合**讨论**场景——多个 Worker 对同一问题独立思考后，通过互相碰撞产生比任何单一轨迹都好的综合解。
+
+HeavySkill 论文的核心发现：讨论阶段的综合推理能突破 Pass@K 天花板——产出 K 条独立轨迹中都不存在的正确解法。这不是投票选最好的，而是碰撞中的创造性推理。
+
+## 2. 核心流程
+
+```
+Orch 发起讨论 → 同题注入 K 个 Worker（独立思考，互不可见）→
+初始观点全部收齐后一次性 bundle 广播 → 进入讨论轮次（Worker 互相回应）→
+轮次耗尽 / Orch 终止 → 各 Worker 输出最终立场 →
+系统综合报告注入 Orch
+```
+
+关键不变量：**初始阶段完全隔离**——Worker 的初始观点被缓冲（buffer），直到所有成员全部提交后才一次性广播。
+
+### 2.1 与现有派单模式的对比
+
+| 维度 | `team send`（派单） | `team discuss`（讨论） |
+|---|---|---|
+| 方向 | Orch → Worker（单向） | Worker ↔ Worker（多向广播） |
+| 目的 | 分治执行不同子任务 | 同题碰撞产生综合解 |
+| Worker 间可见性 | 完全隔离 | 讨论组内互相可见（讨论阶段） |
+| Orch 角色 | 派单者 + 收报者 | 发起者 + 旁听者（仅 DB/UI）+ 最终综合者 |
+| 终止条件 | Worker report | 轮次耗尽 / Orch --end / 绝对消息上限 |
+
+## 3. 协议设计
+
+### 3.1 API 端点
+
+```
+POST /api/team/discuss/start     — Orch/UI 创建讨论组
+POST /api/team/discuss/message   — Worker 发送讨论消息
+POST /api/team/discuss/conclude  — Worker 提交最终立场
+POST /api/team/discuss/end       — Orch/UI 强制终止
+POST /api/team/discuss/skip      — Orch/UI 跳过某个 Worker
+```
+
+### 3.2 CLI 命令
+
+```bash
+# Orch 创建讨论组（仅 Orch/UI 可调用）
+team discuss --start --members "<worker1>,<worker2>" --topic "<question>" [--rounds 3]
+
+# Worker 发送讨论消息（仅讨论组 active member 可调用）
+team discuss "<message>"
+
+# Worker 提交最终立场（concluding 阶段）
+team discuss --conclude "<final-position>"
+
+# Orch 强制终止
+team discuss --end [--reason "<reason>"]
+
+# Orch 跳过卡住的 Worker（不用自动超时）
+team discuss --skip <worker-name>
+```
+
+### 3.3 Authz 规则
+
+- `discuss/start`、`discuss/end`、`discuss/skip`：仅 Orch 或 UI token
+- `discuss/message`、`discuss/conclude`：仅该 group 的 active member Worker
+- Worker authz 白名单新增：`discuss`（现有：report, status, help）
+
+### 3.4 约束：一个 Worker 同一时间只能在一个活跃讨论组
+
+MVP 不支持 Worker 同时参与多组讨论。`discuss/start` 时校验所有 members 均不在其他活跃组中。
+
+### 3.5 前置校验
+
+`discuss/start` 时必须验证：
+- 所有 member Worker 的 `pending_task_count == 0`（不能同时执行派单）
+- 所有 member Worker 有 active PTY run（否则无法注入 stdin）
+
+## 4. 消息注入格式
+
+### 4.1 独立思考邀请（系统 → Worker）
+
+```
+[Hive 讨论：你被邀请参与讨论]
+话题：<topic>
+成员：<worker1>, <worker2>, <worker3>
+规则：
+1. 请独立思考这个问题，形成你的初始观点
+2. 完成后用 `team discuss "<your-initial-position>"` 发表
+3. 你的观点会被缓冲，直到所有成员都提交后才会互相可见
+4. 之后进入讨论阶段（共 N 轮），你可以回应其他成员的观点
+5. 讨论目标：通过碰撞产生新的洞察，而非简单同意某人
+```
+
+### 4.2 初始观点 Bundle 广播（系统 → 所有 Worker）
+
+所有初始观点收齐后，一次性广播：
+
+```
+[Hive 讨论：所有成员初始观点（共 K 人）]
+
+@<Worker1> 的观点：
+<initial_position_1>
+
+@<Worker2> 的观点：
+<initial_position_2>
+
+@<Worker3> 的观点：
+<initial_position_3>
+
+---
+讨论阶段开始（第 1 轮/共 N 轮）。请回应其他成员的观点：指出你同意/不同意的部分，提出新的角度，或尝试综合不同观点。
+用 `team discuss "<your-reply>"` 发言。
+```
+
+### 4.3 讨论阶段（Worker → Worker 广播）
+
+```
+[Hive 讨论：来自 @<name> (第 N 轮/共 M 轮)]
+<message-text>
+```
+
+### 4.4 Conclude 邀请（系统 → 所有 Worker）
+
+```
+[Hive 讨论：讨论轮次结束，请提交最终结论]
+请综合本次讨论的所有观点和碰撞，用 `team discuss --conclude "<your-final-answer>"` 提交你的最终结论。
+你的结论应该是经过讨论后的综合判断，可以不同于你的初始观点。
+```
+
+### 4.5 Orch 综合报告（系统 → Orch）
+
+讨论 concluded 后，系统注入 Orch：
+
+```
+[Hive 讨论结果：讨论组 <id> 已结束]
+话题：<topic>
+参与者：<members>
+轮次：<actual_rounds>/<max_rounds>
+消息总数：<count>
+
+## 各成员初始观点
+@Worker1: <initial_position_1>
+@Worker2: <initial_position_2>
+
+## 各成员最终结论
+@Worker1: <final_position_1>
+@Worker2: <final_position_2>
+
+## 关键分歧与变化
+- @Worker1 初始主张 X，讨论后转向 Y
+- @Worker2 始终坚持 Z，理由是 ...
+
+请综合以上观点做出最终决策。注意：不要简单选择多数派，而是从各方观点中提取互补洞察，形成综合判断。
+```
+
+## 5. 讨论组生命周期
+
+### 5.1 Group 状态
+
+```
+thinking → discussing → concluding → concluded
+    ↓           ↓            ↓
+    └───────────┴────────────┴──→ cancelled
+```
+
+| 状态 | 含义 | 进入条件 |
+|---|---|---|
+| `thinking` | 等待所有 member 提交初始观点 | discuss/start |
+| `discussing` | 讨论进行中，Worker 互相广播 | 所有 member 提交初始观点 |
+| `concluding` | 等待所有 member 提交最终结论 | rounds 耗尽 or 绝对消息上限 |
+| `concluded` | 完成，报告已注入 Orch | 所有 member 提交 final position |
+| `cancelled` | Orch 强制终止 | discuss/end |
+
+### 5.2 Member 状态
+
+| 状态 | 含义 |
+|---|---|
+| `invited` | 已注入讨论邀请，等待初始观点 |
+| `initial_submitted` | 已提交初始观点（缓冲中） |
+| `active` | 讨论阶段活跃 |
+| `round_submitted` | 本轮已发言 |
+| `skipped` | 被 Orch skip |
+| `final_submitted` | 已提交最终结论 |
+| `failed` | PTY 退出 |
+
+### 5.3 边界情况处理
+
+- **Worker PTY 退出**：标记 member `failed`，通知 Orch（旁听消息），组可继续（跳过该 member）
+- **thinking 阶段 skip**：Orch 可 skip 未提交初始观点的 Worker，剩余 member 够 2 人即可进入 discussing
+- **重复发送**：同一 round 同一 Worker 的第二条消息被服务端拒绝（409）
+- **Orch PTY 退出**：讨论继续进行，结果持久化到 DB，Orch 重启后可回放
+
+## 6. 防死循环机制
+
+| 机制 | 说明 |
+|---|---|
+| 每 Worker 每 round 限 1 条 | 服务端 `UNIQUE(group_id, round, from_agent_id)` 约束 |
+| 硬上限 rounds | `--rounds N`（默认 3），rounds 耗尽强制进入 concluding |
+| 绝对消息上限 | `max_messages = 20`（含 initial），超限强制进入 concluding |
+| Orch 手动 skip | 卡住的 Worker 由 Orch 手动跳过，不做自动超时 |
+| 组大小上限 | K ≤ 5（默认 3） |
+
+**不做共识检测**（MVP）：对齐 HeavySkill 原意——讨论目标是产生新解，不是达成一致。
+
+## 7. Orch 旁听策略
+
+### 默认：DB + UI 旁听（不注入 Orch stdin）
+
+- 讨论消息实时写入 DB，前端通过 WebSocket subscription 推送到 Discussion Panel
+- Orch stdin **不**实时注入讨论消息（避免 LLM 自动响应干扰讨论）
+- 仅在讨论 concluded 后，将综合报告一次性注入 Orch stdin
+
+### 可选：`--listen=stdin`
+
+创建时可选 `team discuss --start --listen=stdin ...`，开启实时 stdin 注入（Orch 每条都看到）。
+
+## 8. 数据模型
+
+```sql
+CREATE TABLE discussion_groups (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  topic TEXT NOT NULL,
+  max_rounds INTEGER NOT NULL DEFAULT 3,
+  current_round INTEGER NOT NULL DEFAULT 0,
+  max_messages INTEGER NOT NULL DEFAULT 20,
+  message_count INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL CHECK (status IN ('thinking','discussing','concluding','concluded','cancelled')),
+  listen_mode TEXT NOT NULL DEFAULT 'db', -- 'db' | 'stdin'
+  created_by TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  concluded_at INTEGER
+);
+
+CREATE INDEX idx_discussion_groups_workspace
+  ON discussion_groups (workspace_id, status);
+
+CREATE TABLE discussion_members (
+  group_id TEXT NOT NULL,
+  agent_id TEXT NOT NULL,
+  agent_name TEXT NOT NULL,
+  member_status TEXT NOT NULL DEFAULT 'invited'
+    CHECK (member_status IN ('invited','initial_submitted','active','round_submitted','skipped','final_submitted','failed')),
+  initial_position TEXT,
+  final_position TEXT,
+  rounds_participated INTEGER NOT NULL DEFAULT 0,
+  last_message_at INTEGER,
+  PRIMARY KEY (group_id, agent_id)
+);
+
+CREATE TABLE discussion_messages (
+  sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+  group_id TEXT NOT NULL,
+  round INTEGER NOT NULL,
+  from_agent_id TEXT NOT NULL,
+  message_type TEXT NOT NULL CHECK (message_type IN ('initial','discuss','conclude')),
+  text TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX idx_discussion_messages_group_round
+  ON discussion_messages (group_id, round, sequence);
+
+CREATE UNIQUE INDEX idx_discussion_messages_one_per_round
+  ON discussion_messages (group_id, round, from_agent_id)
+  WHERE message_type = 'discuss';
+```
+
+## 9. 消息路由实现
+
+### 9.1 Per-agent 写入队列
+
+为保证同一 Worker 收到的消息顺序与 DB sequence 一致，使用 per-agent Promise chain：
+
+```typescript
+const writeQueues = new Map<string, Promise<void>>()
+
+const enqueueStdinWrite = (agentId: string, text: string) => {
+  const prev = writeQueues.get(agentId) ?? Promise.resolve()
+  const next = prev.then(() => writeToActiveAgentRun(agentId, text))
+  writeQueues.set(agentId, next)
+}
+```
+
+### 9.2 广播流程
+
+1. Worker A POST `/api/team/discuss/message`
+2. 服务端验证：A 是 active member、group 在 discussing 阶段、本轮 A 未发过言
+3. 持久化到 `discussion_messages`
+4. 更新 `message_count`、member `last_message_at`、member status → `round_submitted`
+5. 对组内除 A 外每个 active member，通过写入队列注入 stdin
+6. 如果 `listen_mode = 'stdin'`，也注入 Orch
+7. 通过 WebSocket emit 通知前端
+8. 检查：本轮所有 active member 均已 `round_submitted` → 推进 round
+
+## 10. 前端 UI
+
+### 10.1 Discussion Panel（右侧 resizable drawer）
+
+- 与终端区域共存，不遮挡主视觉焦点
+- 按轮次分组，消息显示前 2-3 行 + expand
+- Typing indicator：未提交当轮观点的 member 显示 "思考中..."
+- 讨论历史列表：concluded 的讨论可回溯
+
+### 10.2 Worker 卡片
+
+- Badge overlay："讨论中 (2/3轮)"，点击 tooltip 显示话题 + 成员
+- 不引入新状态枚举，讨论通过独立的 `active_discussion_count` 影响是否显示 badge
+
+### 10.3 触发入口
+
+- Orch 终端自然语言触发（"让大家讨论一下 X"）
+- Workspace toolbar "New Discussion" 按钮 → dialog 选 members + 输入 topic
+
+### 10.4 实时更新
+
+- 新增 tRPC subscription：`discussion.onMessage`、`discussion.onStateChange`
+- 不用 polling
+
+## 11. 实现分阶段
+
+### Phase 1: MVP（当前）
+
+1. DB schema（discussion_groups / discussion_members / discussion_messages）
+2. 后端 4 个 API 端点 + authz 扩展
+3. `team` CLI discuss 子命令
+4. 消息路由 + per-agent 写入队列
+5. 生命周期状态机 + round 推进逻辑
+6. Orch 综合报告注入
+7. 前端 Discussion Panel（右侧 drawer）
+8. WebSocket subscription
+
+### Phase 2: 增强
+
+- Orch 参与模式（phase-gated：Orch 也要先独立提交再看别人）
+- 异构模型讨论
+- 角色化讨论 prompt 模板
+- 讨论回放 timeline UI
+- `--skip` 命令实现
+
+### Phase 3: 自动触发
+
+- Orch 角色模板内置讨论触发规则
+- 讨论结果自动接入后续任务分配

--- a/src/server/discussion-message-router.ts
+++ b/src/server/discussion-message-router.ts
@@ -1,0 +1,226 @@
+import type {
+  DiscussionGroup,
+  DiscussionMember,
+  DiscussionMessage,
+} from './discussion-operations.js'
+
+// --- Per-agent write queue (ensures ordered stdin injection) ---
+
+const writeQueues = new Map<string, Promise<void>>()
+
+type WriteFn = (workspaceId: string, agentId: string, text: string) => void
+
+const enqueueWrite = (
+  workspaceId: string,
+  agentId: string,
+  text: string,
+  writeFn: WriteFn
+): Promise<void> => {
+  const key = `${workspaceId}:${agentId}`
+  const prev = writeQueues.get(key) ?? Promise.resolve()
+  const next = prev.then(() => {
+    writeFn(workspaceId, agentId, text)
+  }).finally(() => {
+    if (writeQueues.get(key) === next) writeQueues.delete(key)
+  })
+  writeQueues.set(key, next)
+  return next
+}
+
+export const clearWriteQueue = (workspaceId: string, agentId: string) => {
+  writeQueues.delete(`${workspaceId}:${agentId}`)
+}
+
+// --- Broadcast ---
+
+export interface BroadcastResult {
+  delivered: string[]
+  failed: string[]
+}
+
+export const broadcastToMembers = async (
+  workspaceId: string,
+  members: DiscussionMember[],
+  excludeAgentId: string,
+  text: string,
+  writeFn: WriteFn
+): Promise<BroadcastResult> => {
+  const delivered: string[] = []
+  const failed: string[] = []
+
+  for (const m of members) {
+    if (
+      m.agent_id !== excludeAgentId &&
+      m.member_status !== 'skipped' &&
+      m.member_status !== 'failed'
+    ) {
+      try {
+        await enqueueWrite(workspaceId, m.agent_id, text, writeFn)
+        delivered.push(m.agent_id)
+      } catch (error) {
+        console.error(`[hive:discussion] stdin write failed for ${m.agent_id}:`, error)
+        failed.push(m.agent_id)
+      }
+    }
+  }
+
+  return { delivered, failed }
+}
+
+export const injectToAgent = (
+  workspaceId: string,
+  agentId: string,
+  text: string,
+  writeFn: WriteFn
+) => {
+  enqueueWrite(workspaceId, agentId, text, writeFn).catch((err) => {
+    console.error(`[hive:discussion] inject failed for ${agentId}:`, err)
+  })
+}
+
+// --- Prompt Formatters ---
+
+export const formatDiscussionInvite = (
+  topic: string,
+  memberNames: string[],
+  maxRounds: number
+): string =>
+  [
+    '[Hive 讨论：你被邀请参与讨论]',
+    `话题：${topic}`,
+    `成员：${memberNames.join(', ')}`,
+    '规则：',
+    '1. 请独立思考这个问题，形成你的初始观点',
+    '2. 完成后用 `team discuss "<your-initial-position>"` 发表',
+    '3. 你的观点会被缓冲，直到所有成员都提交后才会互相可见',
+    `4. 之后进入讨论阶段（共 ${maxRounds} 轮），你可以回应其他成员的观点`,
+    '5. 讨论目标：通过碰撞产生新的洞察，而非简单同意某人',
+  ].join('\n')
+
+export const formatInitialBundle = (
+  positions: Array<{ name: string; text: string }>,
+  round: number,
+  maxRounds: number
+): string => {
+  const lines = [`[Hive 讨论：所有成员初始观点（共 ${positions.length} 人）]`, '']
+  for (const p of positions) {
+    lines.push(`@${p.name} 的观点：`)
+    lines.push(p.text)
+    lines.push('')
+  }
+  lines.push('---')
+  lines.push(
+    `讨论阶段开始（第 ${round} 轮/共 ${maxRounds} 轮）。`
+  )
+  lines.push('')
+  lines.push('请按以下结构回应（每条都要回答）：')
+  lines.push('1. 【最强论点】其他人最强的论点是什么？为什么强？')
+  lines.push('2. 【最弱假设】最危险/最弱的假设是什么？（包括你自己的）')
+  lines.push('3. 【反例】一个具体的反例或失败场景')
+  lines.push('4. 【综合方案】一个新的综合方案（不能完全等于任何人的初始观点）')
+  lines.push('5. 【信心变化】你的信心变化（提高/降低/不变，为什么）')
+  lines.push('')
+  lines.push('用 `team discuss "<your-reply>"` 发言。')
+  return lines.join('\n')
+}
+
+export const formatDiscussMessage = (
+  senderName: string,
+  round: number,
+  maxRounds: number,
+  text: string
+): string =>
+  [
+    `[Hive 讨论：来自 @${senderName} (第 ${round} 轮/共 ${maxRounds} 轮)]`,
+    text,
+    '',
+    '---',
+    '请按结构回应：1.最强论点 2.最弱假设 3.反例 4.综合方案 5.信心变化',
+    '用 `team discuss "<your-reply>"` 发言。',
+  ].join('\n')
+
+export const formatConcludeInvite = (): string =>
+  [
+    '[Hive 讨论：讨论轮次结束，请提交最终结论]',
+    '请综合本次讨论的所有观点和碰撞，用 `team discuss --final "<your-final-answer>"` 提交你的最终结论。',
+    '你的结论应该是经过讨论后的综合判断，可以不同于你的初始观点。',
+  ].join('\n')
+
+export const formatCancelNotice = (reason?: string): string =>
+  [
+    '[Hive 讨论：讨论已被终止]',
+    reason ? `原因：${reason}` : '讨论已被 Orchestrator 终止。',
+    '你可以继续执行其他任务。',
+  ].join('\n')
+
+export const formatSynthesisReport = (
+  group: DiscussionGroup,
+  members: DiscussionMember[],
+  messages: DiscussionMessage[]
+): string => {
+  const activeMembers = members.filter(
+    (m) => m.member_status !== 'skipped' && m.member_status !== 'failed'
+  )
+  const memberNames = activeMembers.map((m) => m.agent_name).join(', ')
+
+  const changedMembers = activeMembers.filter(
+    (m) => m.initial_position && m.final_position && m.initial_position !== m.final_position
+  )
+  const unchangedMembers = activeMembers.filter(
+    (m) => m.initial_position && m.final_position && m.initial_position === m.final_position
+  )
+
+  const lines = [
+    `[Hive 讨论结果：讨论组 ${group.id} 已结束]`,
+    `话题：${group.topic}`,
+    `参与者：${memberNames}`,
+    `轮次：${group.current_round}/${group.max_rounds} | 消息数：${messages.length}`,
+    '',
+    '## 1. Discussion Delta — 讨论涌现的新洞察',
+    '（以下内容在讨论开始前不存在于任何单一成员的观点中）',
+  ]
+
+  for (const m of changedMembers) {
+    lines.push(`- @${m.agent_name} 的综合判断：${m.final_position}`)
+  }
+  if (changedMembers.length === 0) {
+    lines.push('- 各成员立场未发生显著变化')
+  }
+
+  lines.push('')
+  lines.push('## 2. Changed Positions — 立场变化')
+
+  for (const m of changedMembers) {
+    lines.push(`- @${m.agent_name}:`)
+    lines.push(`  初始：${m.initial_position}`)
+    lines.push(`  最终：${m.final_position}`)
+  }
+  if (changedMembers.length === 0) {
+    lines.push('- 无成员改变立场')
+  }
+
+  lines.push('')
+  lines.push('## 3. Unresolved Disagreements — 未解分歧')
+
+  if (unchangedMembers.length > 1) {
+    for (const m of unchangedMembers) {
+      lines.push(`- @${m.agent_name} 坚持：${m.final_position}`)
+    }
+  } else {
+    lines.push('- 无显著未解分歧')
+  }
+
+  lines.push('')
+  lines.push('## 4. Decision-ready Recommendation — 综合建议')
+  lines.push('请基于以上 Delta 和分歧，形成你的最终决策。关注：')
+  lines.push('- 讨论中新涌现的洞察（Delta 部分）优先于初始观点')
+  lines.push('- 未解分歧的双方各有什么核心担忧')
+  lines.push('- 是否存在综合方案能同时回应双方担忧')
+
+  lines.push('')
+  lines.push('## 5. Suggested Next Actions — 后续行动')
+  lines.push('- 基于讨论结果，分配具体实施任务')
+  lines.push('- 对未解分歧设立验证实验或 POC')
+
+  return lines.join('\n')
+}

--- a/src/server/discussion-operations.ts
+++ b/src/server/discussion-operations.ts
@@ -1,0 +1,761 @@
+import { randomUUID } from 'node:crypto'
+import type { Database } from 'better-sqlite3'
+
+import { BadRequestError, ConflictError } from './http-errors.js'
+
+// --- Types ---
+
+export interface DiscussionGroup {
+  id: string
+  workspace_id: string
+  topic: string
+  max_rounds: number
+  current_round: number
+  max_messages: number
+  message_count: number
+  status: DiscussionGroupStatus
+  listen_mode: 'db' | 'stdin'
+  orch_participates: number
+  created_by: string
+  created_at: number
+  concluded_at: number | null
+}
+
+export type DiscussionGroupStatus =
+  | 'thinking'
+  | 'discussing'
+  | 'concluding'
+  | 'concluded'
+  | 'cancelled'
+
+export interface DiscussionMember {
+  group_id: string
+  agent_id: string
+  agent_name: string
+  role: 'worker' | 'orchestrator'
+  member_status: DiscussionMemberStatus
+  initial_position: string | null
+  final_position: string | null
+  rounds_participated: number
+  last_message_at: number | null
+}
+
+export type DiscussionMemberStatus =
+  | 'invited'
+  | 'initial_submitted'
+  | 'active'
+  | 'round_submitted'
+  | 'skipped'
+  | 'final_submitted'
+  | 'failed'
+
+export interface DiscussionMessage {
+  sequence: number
+  group_id: string
+  round: number
+  from_agent_id: string
+  message_type: 'initial' | 'discuss' | 'conclude' | 'system'
+  text: string
+  created_at: number
+}
+
+export interface StartDiscussionInput {
+  createdBy: string
+  listenMode?: 'db' | 'stdin'
+  maxRounds?: number
+  memberAgentIds: string[]
+  orchParticipates?: boolean
+  topic: string
+  workspaceId: string
+}
+
+export interface StartDiscussionResult {
+  group: DiscussionGroup
+  members: DiscussionMember[]
+}
+
+export interface SubmitResult {
+  group: DiscussionGroup
+  members: DiscussionMember[]
+  transitioned: boolean
+  newStatus: DiscussionGroupStatus | null
+}
+
+export interface ActiveDiscussionForAgent {
+  group: DiscussionGroup
+  member: DiscussionMember
+  messages: DiscussionMessage[]
+}
+
+// --- Operations Factory ---
+
+export const createDiscussionOperations = (db: Database) => {
+  const getGroup = (groupId: string): DiscussionGroup => {
+    const row = db.prepare('SELECT * FROM discussion_groups WHERE id = ?').get(groupId) as
+      | DiscussionGroup
+      | undefined
+    if (!row) throw new ConflictError(`Discussion group not found: ${groupId}`)
+    return row
+  }
+
+  const getGroupForWorkspace = (groupId: string, workspaceId: string): DiscussionGroup => {
+    const group = getGroup(groupId)
+    if (group.workspace_id !== workspaceId) {
+      throw new ConflictError(`Discussion group not found: ${groupId}`)
+    }
+    return group
+  }
+
+  const getMembers = (groupId: string): DiscussionMember[] =>
+    db
+      .prepare('SELECT * FROM discussion_members WHERE group_id = ?')
+      .all(groupId) as DiscussionMember[]
+
+  const getActiveMembers = (groupId: string): DiscussionMember[] =>
+    db
+      .prepare(
+        `SELECT * FROM discussion_members WHERE group_id = ? AND member_status NOT IN ('skipped','failed')`
+      )
+      .all(groupId) as DiscussionMember[]
+
+  const getMember = (groupId: string, agentId: string): DiscussionMember => {
+    const row = db
+      .prepare('SELECT * FROM discussion_members WHERE group_id = ? AND agent_id = ?')
+      .get(groupId, agentId) as DiscussionMember | undefined
+    if (!row) throw new ConflictError(`Agent ${agentId} is not a member of group ${groupId}`)
+    return row
+  }
+
+  const getMessages = (groupId: string): DiscussionMessage[] =>
+    db
+      .prepare('SELECT * FROM discussion_messages WHERE group_id = ? ORDER BY sequence ASC')
+      .all(groupId) as DiscussionMessage[]
+
+  const getPhaseKey = (group: DiscussionGroup): string => {
+    if (group.status === 'thinking') return 'thinking:0'
+    if (group.status === 'discussing') return `discussing:${group.current_round}`
+    if (group.status === 'concluding') return 'concluding:0'
+    return 'terminal'
+  }
+
+  const getActiveGroupForAgent = (workspaceId: string, agentId: string): DiscussionGroup | null => {
+    const row = db
+      .prepare(
+        `SELECT g.* FROM discussion_groups g
+         JOIN discussion_members m ON g.id = m.group_id
+         WHERE g.workspace_id = ? AND m.agent_id = ? AND g.status IN ('thinking','discussing','concluding')`
+      )
+      .get(workspaceId, agentId) as DiscussionGroup | undefined
+    return row ?? null
+  }
+
+  const getActiveDiscussionsForAgent = (
+    workspaceId: string,
+    agentId: string
+  ): ActiveDiscussionForAgent[] => {
+    const rows = db
+      .prepare(
+        `SELECT
+           g.id AS group_id,
+           g.workspace_id,
+           g.topic,
+           g.max_rounds,
+           g.current_round,
+           g.max_messages,
+           g.message_count,
+           g.status,
+           g.listen_mode,
+           g.orch_participates,
+           g.created_by,
+           g.created_at,
+           g.concluded_at,
+           m.agent_id,
+           m.agent_name,
+           m.role,
+           m.member_status,
+           m.initial_position,
+           m.final_position,
+           m.rounds_participated,
+           m.last_message_at
+         FROM discussion_groups g
+         JOIN discussion_members m ON g.id = m.group_id
+         WHERE g.workspace_id = ?
+           AND m.agent_id = ?
+           AND g.status IN ('thinking','discussing','concluding')
+           AND m.member_status NOT IN ('skipped','failed')
+         ORDER BY g.created_at ASC`
+      )
+      .all(workspaceId, agentId) as Array<{
+      agent_id: string
+      agent_name: string
+      concluded_at: number | null
+      created_at: number
+      created_by: string
+      current_round: number
+      final_position: string | null
+      group_id: string
+      initial_position: string | null
+      last_message_at: number | null
+      listen_mode: 'db' | 'stdin'
+      max_messages: number
+      max_rounds: number
+      member_status: DiscussionMemberStatus
+      message_count: number
+      orch_participates: number
+      role: 'worker' | 'orchestrator'
+      rounds_participated: number
+      status: DiscussionGroupStatus
+      topic: string
+      workspace_id: string
+    }>
+
+    return rows.map((row) => ({
+      group: {
+        id: row.group_id,
+        workspace_id: row.workspace_id,
+        topic: row.topic,
+        max_rounds: row.max_rounds,
+        current_round: row.current_round,
+        max_messages: row.max_messages,
+        message_count: row.message_count,
+        status: row.status,
+        listen_mode: row.listen_mode,
+        orch_participates: row.orch_participates,
+        created_by: row.created_by,
+        created_at: row.created_at,
+        concluded_at: row.concluded_at,
+      },
+      member: {
+        group_id: row.group_id,
+        agent_id: row.agent_id,
+        agent_name: row.agent_name,
+        role: row.role,
+        member_status: row.member_status,
+        initial_position: row.initial_position,
+        final_position: row.final_position,
+        rounds_participated: row.rounds_participated,
+        last_message_at: row.last_message_at,
+      },
+      messages: getMessages(row.group_id),
+    }))
+  }
+
+  const getActiveGroupsForWorkspace = (workspaceId: string): DiscussionGroup[] =>
+    db
+      .prepare(
+        `SELECT * FROM discussion_groups WHERE workspace_id = ? AND status IN ('thinking','discussing','concluding')`
+      )
+      .all(workspaceId) as DiscussionGroup[]
+
+  const updateGroupStatus = (
+    groupId: string,
+    status: DiscussionGroupStatus,
+    extra?: Record<string, unknown>
+  ) => {
+    if (extra && Object.keys(extra).length > 0) {
+      const sets = [`status = ?`, ...Object.keys(extra).map((k) => `${k} = ?`)]
+      const values = [status, ...Object.values(extra), groupId]
+      db.prepare(`UPDATE discussion_groups SET ${sets.join(', ')} WHERE id = ?`).run(...values)
+    } else {
+      db.prepare('UPDATE discussion_groups SET status = ? WHERE id = ?').run(status, groupId)
+    }
+  }
+
+  const updateMemberStatus = (
+    groupId: string,
+    agentId: string,
+    memberStatus: DiscussionMemberStatus
+  ) => {
+    db.prepare(
+      'UPDATE discussion_members SET member_status = ? WHERE group_id = ? AND agent_id = ?'
+    ).run(memberStatus, groupId, agentId)
+  }
+
+  const incrementMessageCount = (groupId: string) => {
+    db.prepare('UPDATE discussion_groups SET message_count = message_count + 1 WHERE id = ?').run(
+      groupId
+    )
+  }
+
+  const transitionToDiscussing = (groupId: string) => {
+    db.prepare(
+      `UPDATE discussion_groups SET status = 'discussing', current_round = 1 WHERE id = ?`
+    ).run(groupId)
+    db.prepare(
+      `UPDATE discussion_members SET member_status = 'active' WHERE group_id = ? AND member_status = 'initial_submitted'`
+    ).run(groupId)
+  }
+
+  const transitionToConcluding = (groupId: string) => {
+    updateGroupStatus(groupId, 'concluding')
+    db.prepare(
+      `UPDATE discussion_members SET member_status = 'active' WHERE group_id = ? AND member_status = 'round_submitted'`
+    ).run(groupId)
+  }
+
+  const advanceRound = (groupId: string, group: DiscussionGroup) => {
+    const nextRound = group.current_round + 1
+    if (nextRound > group.max_rounds) {
+      transitionToConcluding(groupId)
+      return 'concluding' as const
+    }
+    db.prepare('UPDATE discussion_groups SET current_round = ? WHERE id = ?').run(
+      nextRound,
+      groupId
+    )
+    db.prepare(
+      `UPDATE discussion_members SET member_status = 'active' WHERE group_id = ? AND member_status = 'round_submitted'`
+    ).run(groupId)
+    return null
+  }
+
+  const allActiveMembersInStatus = (groupId: string, status: DiscussionMemberStatus): boolean => {
+    const count = db
+      .prepare(
+        `SELECT COUNT(*) as c FROM discussion_members
+         WHERE group_id = ? AND member_status NOT IN ('skipped','failed') AND member_status != ?`
+      )
+      .get(groupId, status) as { c: number }
+    return count.c === 0
+  }
+
+  const shouldInjectSync = (groupId: string, agentId: string, agentRunId: string): boolean => {
+    const group = getGroup(groupId)
+    const phaseKey = getPhaseKey(group)
+    const row = db
+      .prepare(
+        `SELECT id FROM discussion_sync_log
+         WHERE group_id = ? AND member_id = ? AND phase_key = ? AND agent_run_id = ?
+         LIMIT 1`
+      )
+      .get(groupId, agentId, phaseKey, agentRunId) as { id: number } | undefined
+    return !row
+  }
+
+  const recordSyncAttempt = (
+    groupId: string,
+    agentId: string,
+    phaseKey: string,
+    agentRunId: string,
+    syncKind: string
+  ) => {
+    db.transaction(() => {
+      const existing = db
+        .prepare(
+          `SELECT id FROM discussion_sync_log
+           WHERE group_id = ? AND member_id = ? AND phase_key = ? AND agent_run_id = ? AND sync_kind = ?
+           LIMIT 1`
+        )
+        .get(groupId, agentId, phaseKey, agentRunId, syncKind) as { id: number } | undefined
+      if (existing) return
+
+      db.prepare(
+        `INSERT INTO discussion_sync_log (member_id, group_id, phase_key, agent_run_id, sync_kind, attempted_at)
+         VALUES (?, ?, ?, ?, ?, ?)`
+      ).run(agentId, groupId, phaseKey, agentRunId, syncKind, Date.now())
+    })()
+  }
+
+  // --- Public API (all mutations wrapped in transactions) ---
+
+  const startDiscussion = (input: StartDiscussionInput): StartDiscussionResult => {
+    const {
+      createdBy,
+      listenMode = 'db',
+      maxRounds = 3,
+      memberAgentIds,
+      orchParticipates = false,
+      topic,
+      workspaceId,
+    } = input
+
+    if (memberAgentIds.length < 2)
+      throw new BadRequestError('Discussion requires at least 2 members')
+    if (memberAgentIds.length > 5) throw new BadRequestError('Discussion allows at most 5 members')
+    if (maxRounds < 1 || maxRounds > 10)
+      throw new BadRequestError('Rounds must be between 1 and 10')
+
+    const groupId = randomUUID()
+    const now = Date.now()
+
+    const insertGroup = db.prepare(`
+      INSERT INTO discussion_groups (id, workspace_id, topic, max_rounds, current_round, max_messages, message_count, status, listen_mode, orch_participates, created_by, created_at)
+      VALUES (?, ?, ?, ?, 0, 20, 0, 'thinking', ?, ?, ?, ?)
+    `)
+
+    const insertMember = db.prepare(`
+      INSERT INTO discussion_members (group_id, agent_id, agent_name, member_status, role, rounds_participated)
+      VALUES (?, ?, ?, 'invited', ?, 0)
+    `)
+
+    const checkActiveGroup = db.prepare(
+      `SELECT g.id FROM discussion_groups g
+       JOIN discussion_members m ON g.id = m.group_id
+       WHERE g.workspace_id = ? AND m.agent_id = ? AND g.status IN ('thinking','discussing','concluding')
+       LIMIT 1`
+    )
+
+    return db.transaction(() => {
+      // F2: Re-check inside transaction for race safety
+      for (const agentId of memberAgentIds) {
+        const existing = checkActiveGroup.get(workspaceId, agentId) as { id: string } | undefined
+        if (existing) {
+          throw new ConflictError(
+            `Agent ${agentId} is already in an active discussion group: ${existing.id}`
+          )
+        }
+      }
+
+      if (orchParticipates) {
+        const existing = checkActiveGroup.get(workspaceId, createdBy) as { id: string } | undefined
+        if (existing) {
+          throw new ConflictError(
+            `Orchestrator ${createdBy} is already in an active discussion group: ${existing.id}`
+          )
+        }
+      }
+
+      insertGroup.run(
+        groupId,
+        workspaceId,
+        topic,
+        maxRounds,
+        listenMode,
+        orchParticipates ? 1 : 0,
+        createdBy,
+        now
+      )
+      for (const agentId of memberAgentIds) {
+        insertMember.run(groupId, agentId, agentId, 'worker')
+      }
+
+      if (orchParticipates) {
+        insertMember.run(groupId, createdBy, createdBy, 'orchestrator')
+      }
+
+      return { group: getGroup(groupId), members: getMembers(groupId) }
+    })()
+  }
+
+  const submitInitialPosition = (groupId: string, agentId: string, text: string): SubmitResult => {
+    return db.transaction(() => {
+      const group = getGroup(groupId)
+      if (group.status !== 'thinking') {
+        throw new ConflictError(
+          `Group ${groupId} is not in thinking phase (current: ${group.status})`
+        )
+      }
+      const member = getMember(groupId, agentId)
+      if (member.member_status !== 'invited') {
+        throw new ConflictError(`Member ${agentId} already submitted initial position`)
+      }
+
+      const now = Date.now()
+      db.prepare(
+        `UPDATE discussion_members SET member_status = 'initial_submitted', initial_position = ?, last_message_at = ? WHERE group_id = ? AND agent_id = ?`
+      ).run(text, now, groupId, agentId)
+
+      db.prepare(
+        `INSERT INTO discussion_messages (group_id, round, from_agent_id, message_type, text, created_at) VALUES (?, 0, ?, 'initial', ?, ?)`
+      ).run(groupId, agentId, text, now)
+
+      incrementMessageCount(groupId)
+
+      const allSubmitted = allActiveMembersInStatus(groupId, 'initial_submitted')
+      let newStatus: DiscussionGroupStatus | null = null
+
+      if (allSubmitted) {
+        transitionToDiscussing(groupId)
+        newStatus = 'discussing'
+      }
+
+      return {
+        group: getGroup(groupId),
+        members: getMembers(groupId),
+        transitioned: !!newStatus,
+        newStatus,
+      }
+    })()
+  }
+
+  const submitMessage = (groupId: string, agentId: string, text: string): SubmitResult => {
+    return db.transaction(() => {
+      const group = getGroup(groupId)
+      if (group.status !== 'discussing') {
+        throw new ConflictError(
+          `Group ${groupId} is not in discussing phase (current: ${group.status})`
+        )
+      }
+      const member = getMember(groupId, agentId)
+      if (member.member_status === 'round_submitted') {
+        throw new ConflictError(
+          `Member ${agentId} already submitted for round ${group.current_round}`
+        )
+      }
+      if (member.member_status === 'skipped' || member.member_status === 'failed') {
+        throw new ConflictError(
+          `Member ${agentId} cannot send messages (status: ${member.member_status})`
+        )
+      }
+
+      const now = Date.now()
+      db.prepare(
+        `INSERT INTO discussion_messages (group_id, round, from_agent_id, message_type, text, created_at) VALUES (?, ?, ?, 'discuss', ?, ?)`
+      ).run(groupId, group.current_round, agentId, text, now)
+
+      db.prepare(
+        `UPDATE discussion_members SET member_status = 'round_submitted', last_message_at = ?, rounds_participated = rounds_participated + 1 WHERE group_id = ? AND agent_id = ?`
+      ).run(now, groupId, agentId)
+
+      incrementMessageCount(groupId)
+
+      const updatedGroup = getGroup(groupId)
+      if (updatedGroup.message_count >= updatedGroup.max_messages) {
+        transitionToConcluding(groupId)
+        return {
+          group: getGroup(groupId),
+          members: getMembers(groupId),
+          transitioned: true,
+          newStatus: 'concluding' as DiscussionGroupStatus,
+        }
+      }
+
+      const allRoundDone = allActiveMembersInStatus(groupId, 'round_submitted')
+      let newStatus: DiscussionGroupStatus | null = null
+
+      if (allRoundDone) {
+        newStatus = advanceRound(groupId, updatedGroup)
+      }
+
+      return {
+        group: getGroup(groupId),
+        members: getMembers(groupId),
+        transitioned: !!newStatus,
+        newStatus,
+      }
+    })()
+  }
+
+  const submitConclusion = (groupId: string, agentId: string, text: string): SubmitResult => {
+    return db.transaction(() => {
+      const group = getGroup(groupId)
+      if (group.status !== 'concluding') {
+        throw new ConflictError(
+          `Group ${groupId} is not in concluding phase (current: ${group.status})`
+        )
+      }
+      const member = getMember(groupId, agentId)
+      if (member.member_status === 'final_submitted') {
+        throw new ConflictError(`Member ${agentId} already submitted final position`)
+      }
+      if (member.member_status === 'skipped' || member.member_status === 'failed') {
+        throw new ConflictError(
+          `Member ${agentId} cannot conclude (status: ${member.member_status})`
+        )
+      }
+
+      const now = Date.now()
+      db.prepare(
+        `UPDATE discussion_members SET member_status = 'final_submitted', final_position = ?, last_message_at = ? WHERE group_id = ? AND agent_id = ?`
+      ).run(text, now, groupId, agentId)
+
+      db.prepare(
+        `INSERT INTO discussion_messages (group_id, round, from_agent_id, message_type, text, created_at) VALUES (?, ?, ?, 'conclude', ?, ?)`
+      ).run(groupId, group.current_round, agentId, text, now)
+
+      incrementMessageCount(groupId)
+
+      const allConcluded = allActiveMembersInStatus(groupId, 'final_submitted')
+      let newStatus: DiscussionGroupStatus | null = null
+
+      if (allConcluded) {
+        db.prepare(
+          `UPDATE discussion_groups SET status = 'concluded', concluded_at = ? WHERE id = ?`
+        ).run(now, groupId)
+        newStatus = 'concluded'
+      }
+
+      return {
+        group: getGroup(groupId),
+        members: getMembers(groupId),
+        transitioned: !!newStatus,
+        newStatus,
+      }
+    })()
+  }
+
+  const endDiscussion = (groupId: string, _reason?: string): DiscussionGroup => {
+    return db.transaction(() => {
+      const group = getGroup(groupId)
+      if (group.status === 'concluded' || group.status === 'cancelled') {
+        throw new ConflictError(`Group ${groupId} is already ${group.status}`)
+      }
+      updateGroupStatus(groupId, 'cancelled', { concluded_at: Date.now() })
+      return getGroup(groupId)
+    })()
+  }
+
+  const skipMember = (groupId: string, agentId: string): SubmitResult => {
+    return db.transaction(() => {
+      const group = getGroup(groupId)
+      if (group.status === 'concluded' || group.status === 'cancelled') {
+        throw new ConflictError(`Group ${groupId} is already ${group.status}`)
+      }
+      const member = getMember(groupId, agentId)
+      if (member.member_status === 'skipped' || member.member_status === 'failed') {
+        throw new ConflictError(`Member ${agentId} is already ${member.member_status}`)
+      }
+
+      updateMemberStatus(groupId, agentId, 'skipped')
+
+      const activeMembers = getActiveMembers(groupId)
+      if (activeMembers.length < 2) {
+        updateGroupStatus(groupId, 'cancelled', { concluded_at: Date.now() })
+        return {
+          group: getGroup(groupId),
+          members: getMembers(groupId),
+          transitioned: true,
+          newStatus: 'cancelled' as DiscussionGroupStatus,
+        }
+      }
+
+      let newStatus: DiscussionGroupStatus | null = null
+
+      if (group.status === 'thinking') {
+        if (allActiveMembersInStatus(groupId, 'initial_submitted')) {
+          transitionToDiscussing(groupId)
+          newStatus = 'discussing'
+        }
+      } else if (group.status === 'discussing') {
+        if (allActiveMembersInStatus(groupId, 'round_submitted')) {
+          newStatus = advanceRound(groupId, group)
+        }
+      } else if (group.status === 'concluding') {
+        if (allActiveMembersInStatus(groupId, 'final_submitted')) {
+          db.prepare(
+            `UPDATE discussion_groups SET status = 'concluded', concluded_at = ? WHERE id = ?`
+          ).run(Date.now(), groupId)
+          newStatus = 'concluded'
+        }
+      }
+
+      return {
+        group: getGroup(groupId),
+        members: getMembers(groupId),
+        transitioned: !!newStatus,
+        newStatus,
+      }
+    })()
+  }
+
+  const markMemberFailed = (groupId: string, agentId: string): SubmitResult => {
+    return db.transaction(() => {
+      updateMemberStatus(groupId, agentId, 'failed')
+
+      const group = getGroup(groupId)
+      if (group.status === 'concluded' || group.status === 'cancelled') {
+        return { group, members: getMembers(groupId), transitioned: false, newStatus: null }
+      }
+
+      const activeMembers = getActiveMembers(groupId)
+      if (activeMembers.length < 2) {
+        updateGroupStatus(groupId, 'cancelled', { concluded_at: Date.now() })
+        return {
+          group: getGroup(groupId),
+          members: getMembers(groupId),
+          transitioned: true,
+          newStatus: 'cancelled' as DiscussionGroupStatus,
+        }
+      }
+
+      let newStatus: DiscussionGroupStatus | null = null
+
+      if (group.status === 'thinking') {
+        if (allActiveMembersInStatus(groupId, 'initial_submitted')) {
+          transitionToDiscussing(groupId)
+          newStatus = 'discussing'
+        }
+      } else if (group.status === 'discussing') {
+        if (allActiveMembersInStatus(groupId, 'round_submitted')) {
+          newStatus = advanceRound(groupId, group)
+        }
+      } else if (group.status === 'concluding') {
+        if (allActiveMembersInStatus(groupId, 'final_submitted')) {
+          db.prepare(
+            `UPDATE discussion_groups SET status = 'concluded', concluded_at = ? WHERE id = ?`
+          ).run(Date.now(), groupId)
+          newStatus = 'concluded'
+        }
+      }
+
+      return {
+        group: getGroup(groupId),
+        members: getMembers(groupId),
+        transitioned: !!newStatus,
+        newStatus,
+      }
+    })()
+  }
+
+  const setMemberName = (groupId: string, agentId: string, name: string) => {
+    db.prepare(
+      'UPDATE discussion_members SET agent_name = ? WHERE group_id = ? AND agent_id = ?'
+    ).run(name, groupId, agentId)
+  }
+
+  const steerDiscussion = (groupId: string, text: string): DiscussionGroup => {
+    const group = getGroup(groupId)
+    if (group.status !== 'discussing') {
+      throw new ConflictError(
+        `Cannot steer: group is not in discussing phase (current: ${group.status})`
+      )
+    }
+    const now = Date.now()
+    db.prepare(
+      `INSERT INTO discussion_messages (group_id, round, from_agent_id, message_type, text, created_at) VALUES (?, ?, '__system__', 'system', ?, ?)`
+    ).run(groupId, group.current_round, text, now)
+    return group
+  }
+
+  const extendRounds = (groupId: string, additionalRounds: number): DiscussionGroup => {
+    const group = getGroup(groupId)
+    if (group.status !== 'discussing') {
+      throw new ConflictError(
+        `Cannot extend: group is not in discussing phase (current: ${group.status})`
+      )
+    }
+    if (additionalRounds < 1) {
+      throw new BadRequestError('additionalRounds must be >= 1')
+    }
+    db.prepare('UPDATE discussion_groups SET max_rounds = max_rounds + ? WHERE id = ?').run(
+      additionalRounds,
+      groupId
+    )
+    return getGroup(groupId)
+  }
+
+  return {
+    endDiscussion,
+    extendRounds,
+    getActiveDiscussionsForAgent,
+    getActiveGroupForAgent,
+    getActiveGroupsForWorkspace,
+    getGroup,
+    getGroupForWorkspace,
+    getMembers,
+    getMessages,
+    getPhaseKey,
+    markMemberFailed,
+    recordSyncAttempt,
+    setMemberName,
+    shouldInjectSync,
+    skipMember,
+    startDiscussion,
+    steerDiscussion,
+    submitConclusion,
+    submitInitialPosition,
+    submitMessage,
+  }
+}
+
+export type DiscussionOperations = ReturnType<typeof createDiscussionOperations>

--- a/src/server/discussion-post-actions.ts
+++ b/src/server/discussion-post-actions.ts
@@ -1,0 +1,80 @@
+import { appendFileSync, existsSync, mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+import { injectAnchor } from './task-anchor.js'
+import { getTasksFilePath } from './tasks-file.js'
+
+const NEXT_ACTIONS_HEADING = /^##\s+\d+\.\s*Next Actions/i
+const LIST_ITEM = /^(?:[-*]\s+|\d+\.\s+)(.+)/
+
+export const parseNextActions = (reportText: string): string[] => {
+  const lines = reportText.split('\n')
+  let inSection = false
+  const actions: string[] = []
+
+  for (const line of lines) {
+    if (NEXT_ACTIONS_HEADING.test(line)) {
+      inSection = true
+      continue
+    }
+    if (inSection && line.startsWith('## ')) break
+    if (inSection) {
+      const m = LIST_ITEM.exec(line)
+      if (m?.[1]) {
+        const text = m[1].trim()
+        if (text.length > 0) actions.push(text)
+      }
+    }
+  }
+
+  return actions
+}
+
+export interface TaskService {
+  createTask(input: {
+    workspaceId: string
+    title: string
+    source: 'discussion'
+    sourceRef?: string
+  }): { id: string; seq: number }
+}
+
+export const appendActionsToTasks = (
+  workspacePath: string,
+  topic: string,
+  actions: string[],
+  taskService?: TaskService,
+  workspaceId?: string,
+  groupId?: string
+): number => {
+  if (actions.length === 0) return 0
+
+  const tasksPath = getTasksFilePath(workspacePath)
+  const dir = dirname(tasksPath)
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+
+  const header = `\n\n## 讨论产出：${topic}\n\n`
+  let items = actions.map((a) => `- [ ] ${a}`).join('\n')
+
+  if (taskService && workspaceId) {
+    const lines = items.split('\n')
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]
+      if (!line) continue
+      const title = line.replace(/^- \[[ x]\]\s*/, '').trim()
+      const task = taskService.createTask({
+        workspaceId,
+        title,
+        source: 'discussion',
+        ...(groupId ? { sourceRef: groupId } : {}),
+      })
+      const taskId = task.id
+      lines[i] = `- [ ] #${task.seq} ${title}`
+      items = lines.join('\n')
+      items = injectAnchor(items, i, taskId)
+    }
+  }
+
+  appendFileSync(tasksPath, `${header}${items}\n`, 'utf8')
+  return actions.length
+}

--- a/src/server/discussion-recovery-injector.ts
+++ b/src/server/discussion-recovery-injector.ts
@@ -1,0 +1,135 @@
+import type {
+  ActiveDiscussionForAgent,
+  DiscussionGroup,
+  DiscussionMember,
+  DiscussionMessage,
+  DiscussionOperations,
+} from './discussion-operations.js'
+import {
+  buildFullRecoveryBrief,
+  buildMinimalDeltaBrief,
+  buildTerminalNotice,
+  type FullRecoveryBriefInput,
+  type MinimalDeltaBriefInput,
+  type TerminalNoticeInput,
+} from './discussion-recovery-templates.js'
+
+export type SyncKind = 'full' | 'minimal' | 'terminal'
+
+export interface DiscussionRecoveryInjectorDeps {
+  discussionOps: Pick<
+    DiscussionOperations,
+    'getActiveDiscussionsForAgent' | 'getPhaseKey' | 'shouldInjectSync' | 'recordSyncAttempt' | 'getMembers'
+  >
+  writeAgentStdin: (workspaceId: string, agentId: string, text: string) => void
+}
+
+const determineSyncKind = (group: DiscussionGroup, member: DiscussionMember): SyncKind => {
+  if (group.status === 'concluded' || group.status === 'cancelled') return 'terminal'
+  if (member.member_status === 'invited' || member.member_status === 'active') return 'full'
+  return 'minimal'
+}
+
+const determineNextAction = (group: DiscussionGroup, member: DiscussionMember): string => {
+  if (group.status === 'thinking') {
+    if (member.member_status === 'invited') return '请提交你的初始观点（team discuss --submit）'
+    return '等待其他成员提交初始观点'
+  }
+  if (group.status === 'discussing') {
+    if (member.member_status === 'active') return '请提交本轮讨论回复（team discuss --submit）'
+    return '等待其他成员完成本轮讨论'
+  }
+  if (group.status === 'concluding') {
+    if (member.role === 'orchestrator') return '请提交讨论结论（team discuss --conclude）'
+    return '等待 Orchestrator 提交结论'
+  }
+  return '讨论已结束，无需操作'
+}
+
+const formatPhase = (group: DiscussionGroup): string => {
+  if (group.status === 'thinking') return '初始观点收集'
+  if (group.status === 'discussing') return '讨论中'
+  if (group.status === 'concluding') return '结论阶段'
+  return group.status
+}
+
+const buildBriefForKind = (
+  kind: SyncKind,
+  group: DiscussionGroup,
+  member: DiscussionMember,
+  messages: DiscussionMessage[],
+  allMembers: DiscussionMember[]
+): string => {
+  if (kind === 'terminal') {
+    const input: TerminalNoticeInput = {
+      topic: group.topic,
+      finalStatus: group.status === 'concluded' ? 'concluded' : 'cancelled',
+    }
+    return buildTerminalNotice(input)
+  }
+
+  if (kind === 'minimal') {
+    const input: MinimalDeltaBriefInput = {
+      topic: group.topic,
+      phase: formatPhase(group),
+      currentRound: group.current_round,
+      nextAction: determineNextAction(group, member),
+    }
+    return buildMinimalDeltaBrief(input)
+  }
+
+  const ownSubmissions = messages
+    .filter((m) => m.from_agent_id === member.agent_id)
+    .slice(-3)
+    .map((m) => m.text.slice(0, 200))
+
+  const visibleMessages = messages
+    .slice(-5)
+    .map((m) => {
+      const name = allMembers.find((mem) => mem.agent_id === m.from_agent_id)?.agent_name ?? m.from_agent_id
+      return { name, text: m.text.slice(0, 200) }
+    })
+
+  const input: FullRecoveryBriefInput = {
+    topic: group.topic,
+    phase: formatPhase(group),
+    currentRound: group.current_round,
+    maxRounds: group.max_rounds,
+    ownSubmissions,
+    visibleMessages,
+    nextAction: determineNextAction(group, member),
+  }
+  return buildFullRecoveryBrief(input)
+}
+
+export const injectDiscussionRecoveryIfNeeded = (
+  workspaceId: string,
+  agentId: string,
+  agentRunId: string,
+  deps: DiscussionRecoveryInjectorDeps
+): void => {
+  const { discussionOps, writeAgentStdin } = deps
+  const discussions = discussionOps.getActiveDiscussionsForAgent(workspaceId, agentId)
+  if (discussions.length === 0) return
+
+  const sections: string[] = []
+
+  for (const { group, member, messages } of discussions) {
+    if (!discussionOps.shouldInjectSync(group.id, agentId, agentRunId)) continue
+
+    const syncKind = determineSyncKind(group, member)
+    const allMembers = discussionOps.getMembers(group.id)
+    const phaseKey = discussionOps.getPhaseKey(group)
+
+    sections.push(buildBriefForKind(syncKind, group, member, messages, allMembers))
+    discussionOps.recordSyncAttempt(group.id, agentId, phaseKey, agentRunId, syncKind)
+  }
+
+  if (sections.length === 0) return
+  writeAgentStdin(workspaceId, agentId, sections.join('\n\n'))
+}
+
+export const createDiscussionRecoveryInjector = (deps: DiscussionRecoveryInjectorDeps) => ({
+  inject: (workspaceId: string, agentId: string, agentRunId: string) =>
+    injectDiscussionRecoveryIfNeeded(workspaceId, agentId, agentRunId, deps),
+})

--- a/src/server/discussion-recovery-templates.ts
+++ b/src/server/discussion-recovery-templates.ts
@@ -1,0 +1,82 @@
+export interface FullRecoveryBriefInput {
+  topic: string
+  phase: string
+  currentRound: number
+  maxRounds: number
+  ownSubmissions: string[]
+  visibleMessages: { name: string; text: string }[]
+  nextAction: string
+}
+
+export interface MinimalDeltaBriefInput {
+  topic: string
+  phase: string
+  currentRound: number
+  nextAction: string
+}
+
+export interface TerminalNoticeInput {
+  topic: string
+  finalStatus: 'concluded' | 'cancelled'
+  synthesisSnippet?: string
+}
+
+export const buildFullRecoveryBrief = (input: FullRecoveryBriefInput): string => {
+  const lines = [
+    `[Hive 系统消息：讨论恢复上下文]`,
+    '',
+    `你在 crash 前参与了讨论「${input.topic}」。`,
+    `当前阶段：${input.phase}，轮次：${input.currentRound}/${input.maxRounds}`,
+    '',
+  ]
+
+  if (input.ownSubmissions.length > 0) {
+    lines.push('## 你之前的提交')
+    for (const sub of input.ownSubmissions) {
+      lines.push(`- ${sub}`)
+    }
+    lines.push('')
+  }
+
+  if (input.visibleMessages.length > 0) {
+    lines.push('## 最近讨论消息')
+    for (const msg of input.visibleMessages) {
+      lines.push(`**${msg.name}**: ${msg.text}`)
+    }
+    lines.push('')
+  }
+
+  lines.push(`## 你现在需要做`)
+  lines.push(input.nextAction)
+
+  return lines.join('\n')
+}
+
+export const buildMinimalDeltaBrief = (input: MinimalDeltaBriefInput): string =>
+  [
+    `[Hive 系统消息：讨论状态变更]`,
+    '',
+    `讨论「${input.topic}」已进入 ${input.phase} 阶段（轮次 ${input.currentRound}）。`,
+    '',
+    `## 你现在需要做`,
+    input.nextAction,
+  ].join('\n')
+
+export const buildTerminalNotice = (input: TerminalNoticeInput): string => {
+  const lines = [
+    `[Hive 系统消息：讨论已${input.finalStatus === 'concluded' ? '结束' : '取消'}]`,
+    '',
+    `讨论「${input.topic}」已${input.finalStatus === 'concluded' ? '达成结论' : '被取消'}。`,
+  ]
+
+  if (input.synthesisSnippet) {
+    lines.push('')
+    lines.push('## 结论摘要')
+    lines.push(input.synthesisSnippet)
+  }
+
+  lines.push('')
+  lines.push('你可以继续执行其他任务。')
+
+  return lines.join('\n')
+}

--- a/src/server/discussion-templates.ts
+++ b/src/server/discussion-templates.ts
@@ -1,0 +1,84 @@
+export interface DiscussionTemplate {
+  id: string
+  name: string
+  description: string
+  defaultRounds: number
+  roles: string[]
+  topicPromptHint: string
+}
+
+export const discussionTemplates: DiscussionTemplate[] = [
+  {
+    id: 'design-review',
+    name: 'Design Review',
+    description: 'Architecture and solution selection — challenge assumptions, find blind spots.',
+    defaultRounds: 3,
+    roles: ['Advocate', 'Critic', 'Integrator'],
+    topicPromptHint: 'Describe the design decision or architecture choice to evaluate.',
+  },
+  {
+    id: 'root-cause-debate',
+    name: 'Root Cause Debate',
+    description: 'Incident or bug hypothesis elimination — competing explanations, evidence check.',
+    defaultRounds: 2,
+    roles: ['Hypothesis-A', 'Hypothesis-B', 'Evidence-Checker'],
+    topicPromptHint: 'Describe the incident/bug symptoms and known context.',
+  },
+  {
+    id: 'risk-review',
+    name: 'Risk Review',
+    description: 'Pre-launch risk assessment — surface risks, propose mitigations.',
+    defaultRounds: 2,
+    roles: ['Optimist', 'Pessimist', 'Mitigator'],
+    topicPromptHint: 'Describe what is about to ship and known risk areas.',
+  },
+  {
+    id: 'compare-approaches',
+    name: 'Compare Approaches',
+    description: 'Technical approach comparison — each member champions one option.',
+    defaultRounds: 3,
+    roles: ['Approach-A', 'Approach-B', 'Approach-C'],
+    topicPromptHint: 'List the approaches to compare and the evaluation criteria.',
+  },
+]
+
+export const getDiscussionTemplate = (id: string): DiscussionTemplate | undefined =>
+  discussionTemplates.find((t) => t.id === id)
+
+export type DiscussionTriggerCondition =
+  | 'task_has_multiple_approaches'
+  | 'task_is_high_risk'
+  | 'task_needs_review'
+  | 'manual'
+
+export interface DiscussionTriggerRule {
+  condition: DiscussionTriggerCondition
+  template_id?: string
+  min_workers?: number
+  description: string
+}
+
+export interface DiscussionTriggers {
+  rules: DiscussionTriggerRule[]
+}
+
+const CONDITION_KEYWORDS: Record<DiscussionTriggerCondition, string[]> = {
+  task_has_multiple_approaches: ['approach', 'option', 'alternative', 'choose', 'compare', 'tradeoff', 'versus', 'vs'],
+  task_is_high_risk: ['risk', 'dangerous', 'breaking', 'migration', 'irreversible', 'production', 'deploy', 'critical'],
+  task_needs_review: ['review', 'audit', 'check', 'validate', 'approve', 'security', 'compliance'],
+  manual: [],
+}
+
+export const evaluateTrigger = (
+  taskDescription: string,
+  triggers: DiscussionTriggerRule[],
+  availableWorkers?: number
+): DiscussionTriggerRule[] => {
+  const lower = taskDescription.toLowerCase()
+  return triggers.filter((rule) => {
+    if (rule.condition === 'manual') return false
+    if (rule.min_workers && availableWorkers !== undefined && availableWorkers < rule.min_workers) return false
+    const keywords = CONDITION_KEYWORDS[rule.condition]
+    return keywords.some((kw) => new RegExp(`\\b${kw}\\b`).test(lower))
+  })
+}

--- a/src/server/routes-discuss.ts
+++ b/src/server/routes-discuss.ts
@@ -1,0 +1,781 @@
+import {
+  type BroadcastResult,
+  broadcastToMembers,
+  clearWriteQueue,
+  formatCancelNotice,
+  formatConcludeInvite,
+  formatDiscussionInvite,
+  formatDiscussMessage,
+  formatInitialBundle,
+  formatSynthesisReport,
+  injectToAgent,
+} from './discussion-message-router.js'
+import { appendActionsToTasks, parseNextActions, type TaskService } from './discussion-post-actions.js'
+import { getDiscussionTemplate } from './discussion-templates.js'
+import { BadRequestError, ConflictError, ForbiddenError } from './http-errors.js'
+import { readJsonBody, route, sendJson } from './route-helpers.js'
+import type { RouteDefinition } from './route-types.js'
+import { authenticateCliAgent, requireCommandForRole } from './team-authz.js'
+import { resolveCommandPresetId } from './team-list-enrichment.js'
+import { requireUiTokenFromRequest } from './ui-auth-helpers.js'
+
+interface DiscussStartBody {
+  project_id: string
+  from_agent_id?: string
+  token?: string
+  members: string[]
+  topic: string
+  rounds?: number
+  listen_mode?: 'db' | 'stdin'
+  template_id?: string
+  orch_participates?: boolean
+}
+
+interface DiscussMessageBody {
+  project_id: string
+  from_agent_id: string
+  token?: string
+  text: string
+}
+
+interface DiscussConcludeBody {
+  project_id: string
+  from_agent_id: string
+  token?: string
+  text: string
+}
+
+interface DiscussEndBody {
+  project_id: string
+  from_agent_id?: string
+  token?: string
+  reason?: string
+  group_id?: string
+}
+
+interface DiscussSkipBody {
+  project_id: string
+  from_agent_id?: string
+  token?: string
+  worker_name: string
+  group_id?: string
+}
+
+const requireNonEmptyString = (value: unknown, field: string): string => {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new BadRequestError(`Missing ${field}`)
+  }
+  return value
+}
+
+const writeToAgentStdin = (
+  store: { writeAgentStdin: (workspaceId: string, agentId: string, text: string) => void },
+  workspaceId: string,
+  agentId: string,
+  text: string
+) => {
+  store.writeAgentStdin(workspaceId, agentId, text)
+}
+
+const handleBroadcastFailures = (
+  store: {
+    discussionOps: { markMemberFailed: (groupId: string, agentId: string) => unknown }
+    markDiscussionLeft: (workspaceId: string, agentId: string) => void
+  },
+  workspaceId: string,
+  groupId: string,
+  result: BroadcastResult
+) => {
+  for (const agentId of result.failed) {
+    try {
+      const failureResult = store.discussionOps.markMemberFailed(groupId, agentId)
+      store.markDiscussionLeft(workspaceId, agentId)
+      if (
+        typeof failureResult === 'object' &&
+        failureResult !== null &&
+        'newStatus' in failureResult &&
+        (failureResult.newStatus === 'cancelled' || failureResult.newStatus === 'concluded') &&
+        'members' in failureResult &&
+        Array.isArray(failureResult.members)
+      ) {
+        markMembersOutOfDiscussion(store, workspaceId, failureResult.members)
+      }
+    } catch {
+      // already failed/skipped
+    }
+  }
+}
+
+const clearAllMemberQueues = (workspaceId: string, members: Array<{ agent_id: string }>) => {
+  for (const m of members) {
+    clearWriteQueue(workspaceId, m.agent_id)
+  }
+}
+
+const markMembersInDiscussion = (
+  store: { markDiscussionJoined: (workspaceId: string, agentId: string) => void },
+  workspaceId: string,
+  members: Array<{ agent_id: string; member_status?: string }>
+) => {
+  for (const member of members) {
+    if (member.member_status !== 'skipped' && member.member_status !== 'failed') {
+      store.markDiscussionJoined(workspaceId, member.agent_id)
+    }
+  }
+}
+
+const markMembersOutOfDiscussion = (
+  store: { markDiscussionLeft: (workspaceId: string, agentId: string) => void },
+  workspaceId: string,
+  members: Array<{ agent_id: string }>
+) => {
+  for (const member of members) {
+    store.markDiscussionLeft(workspaceId, member.agent_id)
+  }
+}
+
+type ConcludedStore = {
+  getWorkspaceSnapshot: (workspaceId: string) => { summary: { path: string } }
+  taskService?: TaskService
+}
+
+const handleConcludedPostActions = (
+  store: ConcludedStore,
+  workspaceId: string,
+  topic: string,
+  reportText: string,
+  orchId: string,
+  writeFn: (ws: string, agentId: string, text: string) => void,
+  groupId?: string
+) => {
+  const actions = parseNextActions(reportText)
+  if (actions.length === 0) return
+
+  try {
+    const workspace = store.getWorkspaceSnapshot(workspaceId)
+    const count = appendActionsToTasks(
+      workspace.summary.path,
+      topic,
+      actions,
+      store.taskService,
+      workspaceId,
+      groupId
+    )
+    if (count > 0) {
+      const notice = store.taskService
+        ? `[Hive 系统消息：讨论「${topic}」已结束，${count} 条建议行动已写入 tasks.md 作为待认领提议（status: proposed）。请用 team task list --status proposed 查看，认领后用 team task done/send 派发]`
+        : `[Hive 系统消息：讨论「${topic}」已结束，${count} 条建议行动已写入 tasks.md]`
+      injectToAgent(workspaceId, orchId, notice, writeFn)
+    }
+  } catch (err) {
+    console.error('[hive:discussion] post-action failed:', err)
+  }
+}
+
+export const discussRoutes: RouteDefinition[] = [
+  route('POST', '/api/team/discuss/start', async ({ request, response, store }) => {
+    const body = await readJsonBody<DiscussStartBody>(request)
+    const projectId = requireNonEmptyString(body.project_id, 'project_id')
+    const topic = requireNonEmptyString(body.topic, 'topic')
+    const memberNames = body.members
+
+    if (!Array.isArray(memberNames) || memberNames.length < 2) {
+      throw new BadRequestError('At least 2 members required')
+    }
+
+    if (body.from_agent_id) {
+      const agent = authenticateCliAgent({
+        fromAgentId: body.from_agent_id,
+        getAgent: store.getAgent,
+        token: body.token,
+        validateToken: store.validateAgentToken,
+        workspaceId: projectId,
+      })
+      requireCommandForRole(agent, 'discuss')
+      if (agent.role !== 'orchestrator') {
+        throw new ForbiddenError('Only orchestrator can start discussions')
+      }
+    } else {
+      requireUiTokenFromRequest(request, store.validateUiToken)
+    }
+
+    const workers = store.listWorkers(projectId)
+    const memberAgentIds: string[] = []
+    for (const name of memberNames) {
+      const worker = workers.find((w) => w.name === name)
+      if (!worker) throw new BadRequestError(`Worker not found: ${name}`)
+      if (worker.pendingTaskCount > 0) {
+        throw new ConflictError(`Worker ${name} has pending tasks, cannot join discussion`)
+      }
+      if (!store.getActiveRunByAgentId(projectId, worker.id)) {
+        throw new ConflictError(`Worker ${name} has no active PTY run`)
+      }
+      memberAgentIds.push(worker.id)
+    }
+
+    const createdBy = body.from_agent_id ?? `${projectId}:orchestrator`
+    const template = body.template_id ? getDiscussionTemplate(body.template_id) : undefined
+    if (body.template_id && !template) {
+      throw new BadRequestError(`Unknown template_id: ${body.template_id}`)
+    }
+    const maxRounds = body.rounds ?? template?.defaultRounds ?? 3
+    const result = store.discussionOps.startDiscussion({
+      createdBy,
+      listenMode: body.listen_mode ?? 'db',
+      maxRounds,
+      memberAgentIds,
+      orchParticipates: body.orch_participates ?? false,
+      topic,
+      workspaceId: projectId,
+    })
+    markMembersInDiscussion(store, projectId, result.members)
+
+    for (const m of result.members) {
+      const worker = workers.find((w) => w.id === m.agent_id)
+      if (worker && worker.name !== m.agent_name) {
+        store.discussionOps.setMemberName(result.group.id, m.agent_id, worker.name)
+      }
+    }
+
+    // Set Orch member name if participating
+    if (body.orch_participates) {
+      store.discussionOps.setMemberName(result.group.id, createdBy, 'Orchestrator')
+    }
+
+    const memberNamesList = result.members.map((m) => {
+      const w = workers.find((w2) => w2.id === m.agent_id)
+      return w?.name ?? m.agent_id
+    })
+    const roleHint = template
+      ? `\n角色分配：${template.roles
+          .slice(0, memberNamesList.length)
+          .map((r, i) => `${memberNamesList[i]} → ${r}`)
+          .join(', ')}`
+      : ''
+    const inviteText =
+      formatDiscussionInvite(topic, memberNamesList, result.group.max_rounds) + roleHint
+
+    const writeFn = (ws: string, agentId: string, text: string) =>
+      writeToAgentStdin(store, ws, agentId, text)
+
+    // Don't send invite to Orch member — they initiated the discussion
+    const inviteMembers = result.members.filter((m) => m.role !== 'orchestrator')
+    const broadcast = await broadcastToMembers(projectId, inviteMembers, '', inviteText, writeFn)
+    handleBroadcastFailures(store, projectId, result.group.id, broadcast)
+
+    sendJson(response, 201, {
+      ok: true,
+      group_id: result.group.id,
+      delivery_status: { delivered: broadcast.delivered.length, failed: broadcast.failed.length },
+    })
+  }),
+
+  route('POST', '/api/team/discuss/message', async ({ request, response, store }) => {
+    const body = await readJsonBody<DiscussMessageBody>(request)
+    const projectId = requireNonEmptyString(body.project_id, 'project_id')
+    const fromAgentId = requireNonEmptyString(body.from_agent_id, 'from_agent_id')
+    const text = requireNonEmptyString(body.text, 'text')
+
+    const agent = authenticateCliAgent({
+      fromAgentId,
+      getAgent: store.getAgent,
+      token: body.token,
+      validateToken: store.validateAgentToken,
+      workspaceId: projectId,
+    })
+    requireCommandForRole(agent, 'discuss')
+
+    const group = store.discussionOps.getActiveGroupForAgent(projectId, fromAgentId)
+    if (!group) {
+      throw new ConflictError('Agent is not in any active discussion group')
+    }
+    store.discussionOps.getGroupForWorkspace(group.id, projectId)
+
+    const writeFn = (ws: string, agentId: string, t: string) =>
+      writeToAgentStdin(store, ws, agentId, t)
+
+    if (group.status === 'thinking') {
+      const result = store.discussionOps.submitInitialPosition(group.id, fromAgentId, text)
+
+      if (result.transitioned && result.newStatus === 'discussing') {
+        const members = result.members
+        const positions = members
+          .filter((m) => m.initial_position !== null)
+          .map((m) => ({ name: m.agent_name, text: m.initial_position! }))
+        const bundleText = formatInitialBundle(positions, 1, result.group.max_rounds)
+        const broadcast = await broadcastToMembers(projectId, members, '', bundleText, writeFn)
+        handleBroadcastFailures(store, projectId, group.id, broadcast)
+
+        if (result.group.listen_mode === 'stdin' && !result.group.orch_participates) {
+          const orchId = `${projectId}:orchestrator`
+          injectToAgent(projectId, orchId, bundleText, writeFn)
+        }
+      }
+
+      sendJson(response, 202, { ok: true, group_id: group.id, phase: result.group.status })
+      return
+    }
+
+    if (group.status === 'concluding') {
+      const result = store.discussionOps.submitConclusion(group.id, fromAgentId, text)
+
+      if (result.transitioned && result.newStatus === 'concluded') {
+        const messages = store.discussionOps.getMessages(group.id)
+        const reportText = formatSynthesisReport(result.group, result.members, messages)
+        const orchId = `${projectId}:orchestrator`
+        injectToAgent(projectId, orchId, reportText, writeFn)
+        handleConcludedPostActions(
+          store,
+          projectId,
+          result.group.topic,
+          reportText,
+          orchId,
+          writeFn,
+          group.id
+        )
+        clearAllMemberQueues(projectId, result.members)
+        markMembersOutOfDiscussion(store, projectId, result.members)
+      }
+
+      sendJson(response, 202, { ok: true, group_id: group.id, phase: result.group.status })
+      return
+    }
+
+    const result = store.discussionOps.submitMessage(group.id, fromAgentId, text)
+
+    const senderMember = result.members.find((m) => m.agent_id === fromAgentId)
+    const senderName = senderMember?.agent_name ?? fromAgentId
+    const msgText = formatDiscussMessage(senderName, group.current_round, group.max_rounds, text)
+    const broadcast = await broadcastToMembers(
+      projectId,
+      result.members,
+      fromAgentId,
+      msgText,
+      writeFn
+    )
+    handleBroadcastFailures(store, projectId, group.id, broadcast)
+
+    if (group.listen_mode === 'stdin' && !group.orch_participates) {
+      const orchId = `${projectId}:orchestrator`
+      injectToAgent(projectId, orchId, msgText, writeFn)
+    }
+
+    if (result.transitioned && result.newStatus === 'concluding') {
+      const concludeText = formatConcludeInvite()
+      await broadcastToMembers(projectId, result.members, '', concludeText, writeFn)
+    }
+
+    sendJson(response, 202, {
+      ok: true,
+      group_id: group.id,
+      phase: result.group.status,
+      round: result.group.current_round,
+      delivery_status: { delivered: broadcast.delivered.length, failed: broadcast.failed.length },
+    })
+  }),
+
+  route('POST', '/api/team/discuss/final', async ({ request, response, store }) => {
+    const body = await readJsonBody<DiscussConcludeBody>(request)
+    const projectId = requireNonEmptyString(body.project_id, 'project_id')
+    const fromAgentId = requireNonEmptyString(body.from_agent_id, 'from_agent_id')
+    const text = requireNonEmptyString(body.text, 'text')
+
+    const agent = authenticateCliAgent({
+      fromAgentId,
+      getAgent: store.getAgent,
+      token: body.token,
+      validateToken: store.validateAgentToken,
+      workspaceId: projectId,
+    })
+    requireCommandForRole(agent, 'discuss')
+
+    const group = store.discussionOps.getActiveGroupForAgent(projectId, fromAgentId)
+    if (!group) {
+      throw new ConflictError('Agent is not in any active discussion group')
+    }
+    store.discussionOps.getGroupForWorkspace(group.id, projectId)
+
+    if (group.status !== 'concluding') {
+      throw new ConflictError(`Group is not in concluding phase (current: ${group.status})`)
+    }
+
+    const result = store.discussionOps.submitConclusion(group.id, fromAgentId, text)
+
+    if (result.transitioned && result.newStatus === 'concluded') {
+      const messages = store.discussionOps.getMessages(group.id)
+      const reportText = formatSynthesisReport(result.group, result.members, messages)
+      const orchId = `${projectId}:orchestrator`
+      const writeFn = (ws: string, agentId: string, t: string) =>
+        writeToAgentStdin(store, ws, agentId, t)
+      injectToAgent(projectId, orchId, reportText, writeFn)
+      handleConcludedPostActions(store, projectId, result.group.topic, reportText, orchId, writeFn, group.id)
+      clearAllMemberQueues(projectId, result.members)
+      markMembersOutOfDiscussion(store, projectId, result.members)
+    }
+
+    sendJson(response, 202, { ok: true, group_id: group.id, phase: result.group.status })
+  }),
+
+  route('POST', '/api/team/discuss/end', async ({ request, response, store }) => {
+    const body = await readJsonBody<DiscussEndBody>(request)
+    const projectId = requireNonEmptyString(body.project_id, 'project_id')
+
+    if (body.from_agent_id) {
+      const agent = authenticateCliAgent({
+        fromAgentId: body.from_agent_id,
+        getAgent: store.getAgent,
+        token: body.token,
+        validateToken: store.validateAgentToken,
+        workspaceId: projectId,
+      })
+      requireCommandForRole(agent, 'discuss')
+      if (agent.role !== 'orchestrator') {
+        throw new ForbiddenError('Only orchestrator can end discussions')
+      }
+    } else {
+      requireUiTokenFromRequest(request, store.validateUiToken)
+    }
+
+    const groupId =
+      body.group_id ??
+      (() => {
+        const groups = store.discussionOps.getActiveGroupsForWorkspace(projectId)
+        if (groups.length === 0) throw new ConflictError('No active discussion group')
+        if (groups.length > 1) throw new BadRequestError('Multiple active groups, specify group_id')
+        return groups[0]!.id
+      })()
+
+    store.discussionOps.getGroupForWorkspace(groupId, projectId)
+
+    const group = store.discussionOps.endDiscussion(groupId, body.reason)
+    const members = store.discussionOps.getMembers(groupId)
+
+    const cancelText = formatCancelNotice(body.reason)
+    const writeFn = (ws: string, agentId: string, t: string) =>
+      writeToAgentStdin(store, ws, agentId, t)
+    await broadcastToMembers(projectId, members, '', cancelText, writeFn)
+    clearAllMemberQueues(projectId, members)
+    markMembersOutOfDiscussion(store, projectId, members)
+
+    sendJson(response, 200, { ok: true, group_id: group.id, status: group.status })
+  }),
+
+  route('POST', '/api/team/discuss/skip', async ({ request, response, store }) => {
+    const body = await readJsonBody<DiscussSkipBody>(request)
+    const projectId = requireNonEmptyString(body.project_id, 'project_id')
+    const workerName = requireNonEmptyString(body.worker_name, 'worker_name')
+
+    if (body.from_agent_id) {
+      const agent = authenticateCliAgent({
+        fromAgentId: body.from_agent_id,
+        getAgent: store.getAgent,
+        token: body.token,
+        validateToken: store.validateAgentToken,
+        workspaceId: projectId,
+      })
+      requireCommandForRole(agent, 'discuss')
+      if (agent.role !== 'orchestrator') {
+        throw new ForbiddenError('Only orchestrator can skip workers')
+      }
+    } else {
+      requireUiTokenFromRequest(request, store.validateUiToken)
+    }
+
+    const groupId =
+      body.group_id ??
+      (() => {
+        const groups = store.discussionOps.getActiveGroupsForWorkspace(projectId)
+        if (groups.length === 0) throw new ConflictError('No active discussion group')
+        if (groups.length > 1) throw new BadRequestError('Multiple active groups, specify group_id')
+        return groups[0]!.id
+      })()
+
+    store.discussionOps.getGroupForWorkspace(groupId, projectId)
+
+    const members = store.discussionOps.getMembers(groupId)
+    const target = members.find((m) => m.agent_name === workerName)
+    if (!target) throw new BadRequestError(`Worker ${workerName} is not in this discussion group`)
+
+    const result = store.discussionOps.skipMember(groupId, target.agent_id)
+    store.markDiscussionLeft(projectId, target.agent_id)
+
+    const writeFn = (ws: string, agentId: string, t: string) =>
+      writeToAgentStdin(store, ws, agentId, t)
+
+    if (result.transitioned) {
+      if (result.newStatus === 'discussing') {
+        const positions = result.members
+          .filter((m) => m.initial_position !== null)
+          .map((m) => ({ name: m.agent_name, text: m.initial_position! }))
+        const bundleText = formatInitialBundle(positions, 1, result.group.max_rounds)
+        const broadcast = await broadcastToMembers(
+          projectId,
+          result.members,
+          '',
+          bundleText,
+          writeFn
+        )
+        handleBroadcastFailures(store, projectId, groupId, broadcast)
+      } else if (result.newStatus === 'concluding') {
+        const concludeText = formatConcludeInvite()
+        await broadcastToMembers(projectId, result.members, '', concludeText, writeFn)
+      } else if (result.newStatus === 'concluded') {
+        const messages = store.discussionOps.getMessages(groupId)
+        const reportText = formatSynthesisReport(result.group, result.members, messages)
+        const orchId = `${projectId}:orchestrator`
+        injectToAgent(projectId, orchId, reportText, writeFn)
+        handleConcludedPostActions(
+          store,
+          projectId,
+          result.group.topic,
+          reportText,
+          orchId,
+          writeFn,
+          groupId
+        )
+        clearAllMemberQueues(projectId, result.members)
+        markMembersOutOfDiscussion(store, projectId, result.members)
+      } else if (result.newStatus === 'cancelled') {
+        clearAllMemberQueues(projectId, result.members)
+        markMembersOutOfDiscussion(store, projectId, result.members)
+      }
+    }
+
+    sendJson(response, 200, {
+      ok: true,
+      group_id: groupId,
+      skipped: workerName,
+      phase: result.group.status,
+    })
+  }),
+
+  route('POST', '/api/team/discuss/steer', async ({ request, response, store }) => {
+    const body = await readJsonBody<{
+      workspace_id: string
+      group_id?: string
+      text: string
+      from_agent_id?: string
+      token?: string
+    }>(request)
+    const projectId = requireNonEmptyString(body.workspace_id, 'workspace_id')
+    const text = requireNonEmptyString(body.text, 'text')
+
+    if (body.from_agent_id) {
+      const agent = authenticateCliAgent({
+        fromAgentId: body.from_agent_id,
+        getAgent: store.getAgent,
+        token: body.token,
+        validateToken: store.validateAgentToken,
+        workspaceId: projectId,
+      })
+      requireCommandForRole(agent, 'discuss')
+      if (agent.role !== 'orchestrator') {
+        throw new ForbiddenError('Only orchestrator can steer discussions')
+      }
+    } else {
+      requireUiTokenFromRequest(request, store.validateUiToken)
+    }
+
+    const groupId =
+      body.group_id ??
+      (() => {
+        const groups = store.discussionOps.getActiveGroupsForWorkspace(projectId)
+        if (groups.length === 0) throw new ConflictError('No active discussion group')
+        if (groups.length > 1) throw new BadRequestError('Multiple active groups, specify group_id')
+        return groups[0]!.id
+      })()
+
+    store.discussionOps.getGroupForWorkspace(groupId, projectId)
+    const group = store.discussionOps.steerDiscussion(groupId, text)
+
+    const members = store.discussionOps.getMembers(groupId)
+    const steerText = `[Hive 讨论：来自 Orchestrator 的引导]\n${text}`
+    const writeFn = (ws: string, agentId: string, t: string) =>
+      writeToAgentStdin(store, ws, agentId, t)
+    const broadcast = await broadcastToMembers(projectId, members, '', steerText, writeFn)
+
+    sendJson(response, 200, {
+      ok: true,
+      group_id: groupId,
+      phase: group.status,
+      delivery_status: { delivered: broadcast.delivered.length, failed: broadcast.failed.length },
+    })
+  }),
+
+  route('POST', '/api/team/discuss/extend', async ({ request, response, store }) => {
+    const body = await readJsonBody<{
+      workspace_id: string
+      group_id?: string
+      rounds?: number
+      from_agent_id?: string
+      token?: string
+    }>(request)
+    const projectId = requireNonEmptyString(body.workspace_id, 'workspace_id')
+    const rounds = typeof body.rounds === 'number' ? body.rounds : 1
+
+    if (body.from_agent_id) {
+      const agent = authenticateCliAgent({
+        fromAgentId: body.from_agent_id,
+        getAgent: store.getAgent,
+        token: body.token,
+        validateToken: store.validateAgentToken,
+        workspaceId: projectId,
+      })
+      requireCommandForRole(agent, 'discuss')
+      if (agent.role !== 'orchestrator') {
+        throw new ForbiddenError('Only orchestrator can extend discussions')
+      }
+    } else {
+      requireUiTokenFromRequest(request, store.validateUiToken)
+    }
+
+    const groupId =
+      body.group_id ??
+      (() => {
+        const groups = store.discussionOps.getActiveGroupsForWorkspace(projectId)
+        if (groups.length === 0) throw new ConflictError('No active discussion group')
+        if (groups.length > 1) throw new BadRequestError('Multiple active groups, specify group_id')
+        return groups[0]!.id
+      })()
+
+    store.discussionOps.getGroupForWorkspace(groupId, projectId)
+    const group = store.discussionOps.extendRounds(groupId, rounds)
+
+    sendJson(response, 200, {
+      ok: true,
+      group_id: groupId,
+      max_rounds: group.max_rounds,
+      phase: group.status,
+    })
+  }),
+
+  route('GET', '/api/team/discuss/active', ({ request, response, store }) => {
+    const url = new URL(request.url ?? '/', 'http://127.0.0.1')
+    const workspaceId = url.searchParams.get('workspace_id')
+    if (!workspaceId) throw new BadRequestError('Missing workspace_id')
+
+    requireUiTokenFromRequest(request, store.validateUiToken)
+
+    const groups = store.discussionOps.getActiveGroupsForWorkspace(workspaceId)
+    const payload = groups.map((g) => {
+      const members = store.discussionOps.getMembers(g.id)
+      const membersWithModel = members.map((m) => ({
+        agent_id: m.agent_id,
+        agent_name: m.agent_name,
+        initial_position: m.initial_position,
+        final_position: m.final_position,
+        rounds_participated: m.rounds_participated,
+        model_label: resolveCommandPresetId(store, workspaceId, m.agent_id),
+      }))
+      return {
+        id: g.id,
+        workspace_id: g.workspace_id,
+        topic: g.topic,
+        max_rounds: g.max_rounds,
+        current_round: g.current_round,
+        max_messages: g.max_messages,
+        message_count: g.message_count,
+        status: g.status,
+        listen_mode: g.listen_mode,
+        created_by: g.created_by,
+        created_at: g.created_at,
+        concluded_at: g.concluded_at,
+        members: membersWithModel,
+      }
+    })
+    sendJson(response, 200, payload)
+  }),
+
+  route('GET', '/api/team/discuss/messages', ({ request, response, store }) => {
+    const url = new URL(request.url ?? '/', 'http://127.0.0.1')
+    const workspaceId = url.searchParams.get('workspace_id')
+    const groupId = url.searchParams.get('group_id')
+    if (!workspaceId) throw new BadRequestError('Missing workspace_id')
+    if (!groupId) throw new BadRequestError('Missing group_id')
+
+    requireUiTokenFromRequest(request, store.validateUiToken)
+
+    store.discussionOps.getGroupForWorkspace(groupId, workspaceId)
+    const messages = store.discussionOps.getMessages(groupId)
+    const members = store.discussionOps.getMembers(groupId)
+    const payload = messages.map((m) => {
+      const member = members.find((mb) => mb.agent_id === m.from_agent_id)
+      return {
+        sequence: m.sequence,
+        group_id: m.group_id,
+        round: m.round,
+        from_agent_id: m.from_agent_id,
+        from_agent_name: member?.agent_name ?? m.from_agent_id,
+        text: m.text,
+        created_at: m.created_at,
+        model_label: resolveCommandPresetId(store, workspaceId, m.from_agent_id),
+      }
+    })
+    sendJson(response, 200, payload)
+  }),
+
+  route('GET', '/api/team/discuss/timeline', ({ request, response, store }) => {
+    const url = new URL(request.url ?? '/', 'http://127.0.0.1')
+    const workspaceId = url.searchParams.get('workspace_id')
+    const groupId = url.searchParams.get('group_id')
+    if (!workspaceId) throw new BadRequestError('Missing workspace_id')
+    if (!groupId) throw new BadRequestError('Missing group_id')
+
+    requireUiTokenFromRequest(request, store.validateUiToken)
+
+    const group = store.discussionOps.getGroupForWorkspace(groupId, workspaceId)
+    const members = store.discussionOps.getMembers(groupId)
+    const messages = store.discussionOps.getMessages(groupId)
+
+    type TimelineEvent = {
+      type: 'created' | 'initial' | 'discuss' | 'system' | 'conclude' | 'concluded'
+      timestamp: number
+      agent_id: string | null
+      agent_name: string | null
+      round: number
+      text: string
+    }
+
+    const events: TimelineEvent[] = []
+
+    events.push({
+      type: 'created',
+      timestamp: group.created_at,
+      agent_id: null,
+      agent_name: null,
+      round: 0,
+      text: JSON.stringify({
+        topic: group.topic,
+        members: members.map((m) => m.agent_name),
+        max_rounds: group.max_rounds,
+      }),
+    })
+
+    for (const msg of messages) {
+      const member = members.find((mb) => mb.agent_id === msg.from_agent_id)
+      events.push({
+        type: msg.message_type as TimelineEvent['type'],
+        timestamp: msg.created_at,
+        agent_id: msg.from_agent_id,
+        agent_name: member?.agent_name ?? msg.from_agent_id,
+        round: msg.round,
+        text: msg.text,
+      })
+    }
+
+    if (group.concluded_at) {
+      events.push({
+        type: 'concluded',
+        timestamp: group.concluded_at,
+        agent_id: null,
+        agent_name: null,
+        round: group.current_round,
+        text: group.status,
+      })
+    }
+
+    events.sort((a, b) => a.timestamp - b.timestamp)
+
+    sendJson(response, 200, { group_id: groupId, status: group.status, events })
+  }),
+]

--- a/src/server/sqlite-schema-v20.ts
+++ b/src/server/sqlite-schema-v20.ts
@@ -1,0 +1,56 @@
+import type { Database } from 'better-sqlite3'
+
+export const applySchemaVersion20 = (db: Database) => {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS discussion_groups (
+      id TEXT PRIMARY KEY,
+      workspace_id TEXT NOT NULL,
+      topic TEXT NOT NULL,
+      max_rounds INTEGER NOT NULL DEFAULT 3,
+      current_round INTEGER NOT NULL DEFAULT 0,
+      max_messages INTEGER NOT NULL DEFAULT 20,
+      message_count INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL CHECK (status IN ('thinking','discussing','concluding','concluded','cancelled')),
+      listen_mode TEXT NOT NULL DEFAULT 'db',
+      created_by TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      concluded_at INTEGER
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_discussion_groups_workspace
+      ON discussion_groups (workspace_id, status);
+
+    CREATE TABLE IF NOT EXISTS discussion_members (
+      group_id TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      agent_name TEXT NOT NULL,
+      member_status TEXT NOT NULL DEFAULT 'invited'
+        CHECK (member_status IN ('invited','initial_submitted','active','round_submitted','skipped','final_submitted','failed')),
+      initial_position TEXT,
+      final_position TEXT,
+      rounds_participated INTEGER NOT NULL DEFAULT 0,
+      last_message_at INTEGER,
+      PRIMARY KEY (group_id, agent_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS discussion_messages (
+      sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+      group_id TEXT NOT NULL,
+      round INTEGER NOT NULL,
+      from_agent_id TEXT NOT NULL,
+      message_type TEXT NOT NULL CHECK (message_type IN ('initial','discuss','conclude')),
+      text TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_discussion_messages_group_round
+      ON discussion_messages (group_id, round, sequence);
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_discussion_messages_one_per_round
+      ON discussion_messages (group_id, round, from_agent_id)
+      WHERE message_type = 'discuss';
+
+    CREATE INDEX IF NOT EXISTS idx_discussion_members_active_agent
+      ON discussion_members (agent_id, group_id);
+  `)
+}

--- a/src/server/sqlite-schema-v21.ts
+++ b/src/server/sqlite-schema-v21.ts
@@ -1,0 +1,29 @@
+import type { Database } from 'better-sqlite3'
+
+export const applySchemaVersion21 = (db: Database) => {
+  db.exec(`
+    CREATE TABLE discussion_messages_new (
+      sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+      group_id TEXT NOT NULL,
+      round INTEGER NOT NULL,
+      from_agent_id TEXT NOT NULL,
+      message_type TEXT NOT NULL CHECK (message_type IN ('initial','discuss','conclude','system')),
+      text TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+
+    INSERT INTO discussion_messages_new (sequence, group_id, round, from_agent_id, message_type, text, created_at)
+      SELECT sequence, group_id, round, from_agent_id, message_type, text, created_at FROM discussion_messages;
+
+    DROP TABLE discussion_messages;
+
+    ALTER TABLE discussion_messages_new RENAME TO discussion_messages;
+
+    CREATE INDEX IF NOT EXISTS idx_discussion_messages_group_round
+      ON discussion_messages (group_id, round, sequence);
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_discussion_messages_one_per_round
+      ON discussion_messages (group_id, round, from_agent_id)
+      WHERE message_type = 'discuss';
+  `)
+}

--- a/src/server/sqlite-schema-v22.ts
+++ b/src/server/sqlite-schema-v22.ts
@@ -1,0 +1,9 @@
+import type { Database } from 'better-sqlite3'
+
+export const applySchemaVersion22 = (db: Database) => {
+  db.exec(`
+    ALTER TABLE discussion_groups ADD COLUMN orch_participates INTEGER NOT NULL DEFAULT 0;
+
+    ALTER TABLE discussion_members ADD COLUMN role TEXT NOT NULL DEFAULT 'worker';
+  `)
+}

--- a/src/server/sqlite-schema-v23.ts
+++ b/src/server/sqlite-schema-v23.ts
@@ -1,0 +1,7 @@
+import type { Database } from 'better-sqlite3'
+
+export const applySchemaVersion23 = (db: Database) => {
+  db.exec(`
+    ALTER TABLE role_templates ADD COLUMN discussion_triggers TEXT;
+  `)
+}

--- a/src/server/sqlite-schema-v24.ts
+++ b/src/server/sqlite-schema-v24.ts
@@ -1,0 +1,53 @@
+import type { Database } from 'better-sqlite3'
+
+export const applySchemaVersion24 = (db: Database) => {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS tasks (
+      id TEXT PRIMARY KEY,
+      workspace_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'open',
+      source TEXT,
+      source_ref TEXT,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_tasks_workspace ON tasks (workspace_id, status);
+
+    CREATE TABLE IF NOT EXISTS task_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      workspace_id TEXT NOT NULL,
+      task_id TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      agent_id TEXT,
+      dispatch_id TEXT,
+      payload TEXT,
+      line_snapshot TEXT,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_task_events_task ON task_events (task_id, created_at);
+
+    CREATE TABLE IF NOT EXISTS discussion_sync_log (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      member_id TEXT NOT NULL,
+      group_id TEXT NOT NULL,
+      phase_key TEXT NOT NULL,
+      agent_run_id TEXT,
+      sync_kind TEXT NOT NULL,
+      attempted_at INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_discussion_sync_log_member
+      ON discussion_sync_log (member_id, group_id);
+  `)
+
+  const columns = new Set(
+    (db.prepare('PRAGMA table_info(dispatches)').all() as Array<{ name: string }>).map(
+      (col) => col.name
+    )
+  )
+  if (!columns.has('task_id')) {
+    db.exec('ALTER TABLE dispatches ADD COLUMN task_id TEXT')
+  }
+}

--- a/src/server/sqlite-schema-v25.ts
+++ b/src/server/sqlite-schema-v25.ts
@@ -1,0 +1,15 @@
+import type { Database } from 'better-sqlite3'
+
+export const applySchemaVersion25 = (db: Database) => {
+  const columns = new Set(
+    (db.prepare('PRAGMA table_info(role_templates)').all() as Array<{ name: string }>).map(
+      (col) => col.name
+    )
+  )
+  if (!columns.has('suggested_name')) {
+    db.exec('ALTER TABLE role_templates ADD COLUMN suggested_name TEXT')
+  }
+  if (!columns.has('command_preset_id')) {
+    db.exec('ALTER TABLE role_templates ADD COLUMN command_preset_id TEXT')
+  }
+}

--- a/src/server/sqlite-schema-v26.ts
+++ b/src/server/sqlite-schema-v26.ts
@@ -1,0 +1,26 @@
+import type { Database } from 'better-sqlite3'
+
+export const applySchemaVersion26 = (db: Database) => {
+  const wsColumns = new Set(
+    (db.prepare('PRAGMA table_info(workspaces)').all() as Array<{ name: string }>).map(
+      (col) => col.name
+    )
+  )
+  if (!wsColumns.has('sort_order')) {
+    db.exec('ALTER TABLE workspaces ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0')
+    const rows = db.prepare('SELECT id FROM workspaces ORDER BY created_at ASC').all() as Array<{
+      id: string
+    }>
+    const stmt = db.prepare('UPDATE workspaces SET sort_order = ? WHERE id = ?')
+    rows.forEach((row, i) => stmt.run(i, row.id))
+  }
+
+  const rtColumns = new Set(
+    (db.prepare('PRAGMA table_info(role_templates)').all() as Array<{ name: string }>).map(
+      (col) => col.name
+    )
+  )
+  if (!rtColumns.has('use_count')) {
+    db.exec('ALTER TABLE role_templates ADD COLUMN use_count INTEGER NOT NULL DEFAULT 0')
+  }
+}

--- a/src/server/sqlite-schema-v27.ts
+++ b/src/server/sqlite-schema-v27.ts
@@ -1,0 +1,26 @@
+import type { Database } from 'better-sqlite3'
+
+export const applySchemaVersion27 = (db: Database) => {
+  const columns = new Set(
+    (db.prepare('PRAGMA table_info(tasks)').all() as Array<{ name: string }>).map(
+      (col) => col.name
+    )
+  )
+  if (!columns.has('seq')) {
+    db.exec('ALTER TABLE tasks ADD COLUMN seq INTEGER')
+
+    const rows = db
+      .prepare('SELECT id, workspace_id FROM tasks ORDER BY workspace_id, created_at ASC')
+      .all() as Array<{ id: string; workspace_id: string }>
+
+    const counters = new Map<string, number>()
+    const stmt = db.prepare('UPDATE tasks SET seq = ? WHERE id = ?')
+    for (const row of rows) {
+      const next = (counters.get(row.workspace_id) ?? 0) + 1
+      counters.set(row.workspace_id, next)
+      stmt.run(next, row.id)
+    }
+
+    db.exec('CREATE UNIQUE INDEX idx_tasks_workspace_seq ON tasks (workspace_id, seq)')
+  }
+}

--- a/src/server/sqlite-schema-v28.ts
+++ b/src/server/sqlite-schema-v28.ts
@@ -1,0 +1,12 @@
+import type { Database } from 'better-sqlite3'
+
+export const applySchemaVersion28 = (db: Database) => {
+  const columns = new Set(
+    (db.prepare('PRAGMA table_info(agent_runs)').all() as Array<{ name: string }>).map(
+      (col) => col.name
+    )
+  )
+  if (!columns.has('checkpoint_json')) {
+    db.exec('ALTER TABLE agent_runs ADD COLUMN checkpoint_json TEXT')
+  }
+}

--- a/src/server/sqlite-schema-v29.ts
+++ b/src/server/sqlite-schema-v29.ts
@@ -1,0 +1,12 @@
+import type { Database } from 'better-sqlite3'
+
+export const applySchemaVersion29 = (db: Database) => {
+  const columns = new Set(
+    (db.prepare('PRAGMA table_info(agent_runs)').all() as Array<{ name: string }>).map(
+      (col) => col.name
+    )
+  )
+  if (!columns.has('tmux_session')) {
+    db.exec('ALTER TABLE agent_runs ADD COLUMN tmux_session TEXT')
+  }
+}

--- a/src/server/sqlite-schema.ts
+++ b/src/server/sqlite-schema.ts
@@ -13,8 +13,19 @@ import { applySchemaVersion15 } from './sqlite-schema-v15.js'
 import { applySchemaVersion16 } from './sqlite-schema-v16.js'
 import { applySchemaVersion17 } from './sqlite-schema-v17.js'
 import { applySchemaVersion18 } from './sqlite-schema-v18.js'
+import { applySchemaVersion19 } from './sqlite-schema-v19.js'
+import { applySchemaVersion20 } from './sqlite-schema-v20.js'
+import { applySchemaVersion21 } from './sqlite-schema-v21.js'
+import { applySchemaVersion22 } from './sqlite-schema-v22.js'
+import { applySchemaVersion23 } from './sqlite-schema-v23.js'
+import { applySchemaVersion24 } from './sqlite-schema-v24.js'
+import { applySchemaVersion25 } from './sqlite-schema-v25.js'
+import { applySchemaVersion26 } from './sqlite-schema-v26.js'
+import { applySchemaVersion27 } from './sqlite-schema-v27.js'
+import { applySchemaVersion28 } from './sqlite-schema-v28.js'
+import { applySchemaVersion29 } from './sqlite-schema-v29.js'
 
-export const CURRENT_SCHEMA_VERSION = 18
+export const CURRENT_SCHEMA_VERSION = 29
 
 export const initializeRuntimeDatabase = (db: Database) => {
   db.exec(`
@@ -244,5 +255,60 @@ export const initializeRuntimeDatabase = (db: Database) => {
   if (!appliedVersions.has(18)) {
     applySchemaVersion18(db)
     db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(18, Date.now())
+  }
+
+  if (!appliedVersions.has(19)) {
+    applySchemaVersion19(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(19, Date.now())
+  }
+
+  if (!appliedVersions.has(20)) {
+    applySchemaVersion20(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(20, Date.now())
+  }
+
+  if (!appliedVersions.has(21)) {
+    applySchemaVersion21(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(21, Date.now())
+  }
+
+  if (!appliedVersions.has(22)) {
+    applySchemaVersion22(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(22, Date.now())
+  }
+
+  if (!appliedVersions.has(23)) {
+    applySchemaVersion23(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(23, Date.now())
+  }
+
+  if (!appliedVersions.has(24)) {
+    applySchemaVersion24(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(24, Date.now())
+  }
+
+  if (!appliedVersions.has(25)) {
+    applySchemaVersion25(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(25, Date.now())
+  }
+
+  if (!appliedVersions.has(26)) {
+    applySchemaVersion26(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(26, Date.now())
+  }
+
+  if (!appliedVersions.has(27)) {
+    applySchemaVersion27(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(27, Date.now())
+  }
+
+  if (!appliedVersions.has(28)) {
+    applySchemaVersion28(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(28, Date.now())
+  }
+
+  if (!appliedVersions.has(29)) {
+    applySchemaVersion29(db)
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(29, Date.now())
   }
 }

--- a/tests/server/discussion-recovery-integration.test.ts
+++ b/tests/server/discussion-recovery-integration.test.ts
@@ -1,0 +1,152 @@
+import Database from 'better-sqlite3'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createDiscussionOperations } from '../../src/server/discussion-operations.js'
+import {
+  injectDiscussionRecoveryIfNeeded,
+  type DiscussionRecoveryInjectorDeps,
+} from '../../src/server/discussion-recovery-injector.js'
+import { initializeRuntimeDatabase } from '../../src/server/sqlite-schema.js'
+
+describe('discussion crash recovery integration', () => {
+  let db: Database.Database
+  let ops: ReturnType<typeof createDiscussionOperations>
+  let writeAgentStdin: ReturnType<typeof vi.fn>
+
+  const buildDeps = (overrides: Partial<DiscussionRecoveryInjectorDeps> = {}): DiscussionRecoveryInjectorDeps => ({
+    discussionOps: ops,
+    writeAgentStdin,
+    ...overrides,
+  })
+
+  beforeEach(() => {
+    db = new Database(':memory:')
+    initializeRuntimeDatabase(db)
+    ops = createDiscussionOperations(db)
+    writeAgentStdin = vi.fn()
+  })
+
+  test('injects full recovery brief when worker crashes during thinking phase', () => {
+    ops.startDiscussion({
+      createdBy: 'ws-1:orchestrator',
+      memberAgentIds: ['worker-a', 'worker-b'],
+      topic: 'API design',
+      workspaceId: 'ws-1',
+    })
+
+    injectDiscussionRecoveryIfNeeded('ws-1', 'worker-a', 'run-new', buildDeps())
+
+    expect(writeAgentStdin).toHaveBeenCalledTimes(1)
+    const injected = writeAgentStdin.mock.calls[0]![2] as string
+    expect(injected).toContain('API design')
+    expect(injected).toContain('初始观点收集')
+    expect(injected).toContain('请提交你的初始观点')
+  })
+
+  test('does not inject when shouldInjectSync returns false (same run already synced)', () => {
+    const { group } = ops.startDiscussion({
+      createdBy: 'ws-1:orchestrator',
+      memberAgentIds: ['worker-a', 'worker-b'],
+      topic: 'already synced',
+      workspaceId: 'ws-1',
+    })
+
+    ops.recordSyncAttempt(group.id, 'worker-a', 'thinking:0', 'run-1', 'full')
+
+    injectDiscussionRecoveryIfNeeded('ws-1', 'worker-a', 'run-1', buildDeps())
+
+    expect(writeAgentStdin).not.toHaveBeenCalled()
+  })
+
+  test('injects terminal notice when discussion is concluded', () => {
+    const { group } = ops.startDiscussion({
+      createdBy: 'ws-1:orchestrator',
+      memberAgentIds: ['worker-a', 'worker-b'],
+      topic: 'concluded topic',
+      workspaceId: 'ws-1',
+    })
+
+    ops.submitInitialPosition(group.id, 'worker-a', 'A pos')
+    ops.submitInitialPosition(group.id, 'worker-b', 'B pos')
+    ops.submitMessage(group.id, 'worker-a', 'A r1')
+    ops.submitMessage(group.id, 'worker-b', 'B r1')
+    ops.submitMessage(group.id, 'worker-a', 'A r2')
+    ops.submitMessage(group.id, 'worker-b', 'B r2')
+    ops.submitMessage(group.id, 'worker-a', 'A r3')
+    ops.submitMessage(group.id, 'worker-b', 'B r3')
+    ops.submitConclusion(group.id, 'worker-a', 'A final')
+    ops.submitConclusion(group.id, 'worker-b', 'B final')
+
+    const concludedGroup = ops.getGroup(group.id)
+    const members = ops.getMembers(group.id)
+
+    const deps = buildDeps({
+      discussionOps: {
+        ...ops,
+        getActiveDiscussionsForAgent: () => [
+          { group: concludedGroup, member: members[0]!, messages: [] },
+        ],
+        shouldInjectSync: () => true,
+      },
+    })
+
+    injectDiscussionRecoveryIfNeeded('ws-1', 'worker-a', 'run-new', deps)
+
+    expect(writeAgentStdin).toHaveBeenCalledTimes(1)
+    const injected = writeAgentStdin.mock.calls[0]![2] as string
+    expect(injected).toContain('结束')
+    expect(injected).toContain('concluded topic')
+  })
+
+  test('same agent_run_id does not trigger duplicate injection (idempotency)', () => {
+    ops.startDiscussion({
+      createdBy: 'ws-1:orchestrator',
+      memberAgentIds: ['worker-a', 'worker-b'],
+      topic: 'idempotent test',
+      workspaceId: 'ws-1',
+    })
+
+    const deps = buildDeps()
+
+    injectDiscussionRecoveryIfNeeded('ws-1', 'worker-a', 'run-x', deps)
+    expect(writeAgentStdin).toHaveBeenCalledTimes(1)
+
+    writeAgentStdin.mockClear()
+    injectDiscussionRecoveryIfNeeded('ws-1', 'worker-a', 'run-x', deps)
+    expect(writeAgentStdin).not.toHaveBeenCalled()
+  })
+
+  test('merges multiple active discussions into single stdin write', () => {
+    const group1 = ops.startDiscussion({
+      createdBy: 'ws-1:orchestrator',
+      memberAgentIds: ['worker-a', 'worker-b'],
+      topic: 'Discussion One',
+      workspaceId: 'ws-1',
+    })
+
+    const group1Members = ops.getMembers(group1.group.id)
+    const memberA1 = group1Members.find((m) => m.agent_id === 'worker-a')!
+
+    const deps = buildDeps({
+      discussionOps: {
+        ...ops,
+        getActiveDiscussionsForAgent: () => [
+          { group: group1.group, member: memberA1, messages: [] },
+          {
+            group: { ...group1.group, id: 'fake-group-2', topic: 'Discussion Two' },
+            member: { ...memberA1, group_id: 'fake-group-2' },
+            messages: [],
+          },
+        ],
+        shouldInjectSync: () => true,
+      },
+    })
+
+    injectDiscussionRecoveryIfNeeded('ws-1', 'worker-a', 'run-multi', deps)
+
+    expect(writeAgentStdin).toHaveBeenCalledTimes(1)
+    const injected = writeAgentStdin.mock.calls[0]![2] as string
+    expect(injected).toContain('Discussion One')
+    expect(injected).toContain('Discussion Two')
+  })
+})

--- a/tests/server/schema-version.test.ts
+++ b/tests/server/schema-version.test.ts
@@ -18,7 +18,7 @@ afterEach(async () => {
   }
 })
 
-const expectDispatchSchema = (db: Database) => {
+const expectDispatchSchema = (db: InstanceType<typeof Database>) => {
   const dispatchTable = db
     .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'dispatches'")
     .get() as { name: string } | undefined
@@ -33,7 +33,7 @@ const expectDispatchSchema = (db: Database) => {
   expect(dispatchIndexes.has('idx_dispatches_open_by_worker')).toBe(true)
 }
 
-const indexColumns = (db: Database, indexName: string) =>
+const indexColumns = (db: InstanceType<typeof Database>, indexName: string) =>
   (db.prepare(`PRAGMA index_info(${indexName})`).all() as Array<{ name: string }>).map(
     (column) => column.name
   )
@@ -137,6 +137,7 @@ describe('schema version', () => {
         'is_builtin',
         'created_at',
         'updated_at',
+        'discussion_triggers',
       ])
     )
     expect(appStateColumns).toEqual(new Set(['key', 'value', 'updated_at']))
@@ -156,6 +157,7 @@ describe('schema version', () => {
         'reported_at',
         'report_text',
         'artifacts',
+        'task_id',
       ])
     )
     expectDispatchSchema(db)
@@ -190,6 +192,19 @@ describe('schema version', () => {
 
       INSERT INTO schema_version (version, applied_at)
       VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8);
+
+      CREATE TABLE role_templates (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        role_type TEXT NOT NULL,
+        description TEXT NOT NULL,
+        default_command TEXT NOT NULL,
+        default_args TEXT NOT NULL,
+        default_env TEXT NOT NULL,
+        is_builtin INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
 
       CREATE TABLE command_presets (
         id TEXT PRIMARY KEY,
@@ -265,6 +280,19 @@ describe('schema version', () => {
 
       INSERT INTO schema_version (version, applied_at)
       VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9);
+
+      CREATE TABLE role_templates (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        role_type TEXT NOT NULL,
+        description TEXT NOT NULL,
+        default_command TEXT NOT NULL,
+        default_args TEXT NOT NULL,
+        default_env TEXT NOT NULL,
+        is_builtin INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
 
       CREATE TABLE command_presets (
         id TEXT PRIMARY KEY,
@@ -376,6 +404,19 @@ describe('schema version', () => {
       INSERT INTO schema_version (version, applied_at)
       VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10);
 
+      CREATE TABLE role_templates (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        role_type TEXT NOT NULL,
+        description TEXT NOT NULL,
+        default_command TEXT NOT NULL,
+        default_args TEXT NOT NULL,
+        default_env TEXT NOT NULL,
+        is_builtin INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+
       CREATE TABLE command_presets (
         id TEXT PRIMARY KEY,
         display_name TEXT NOT NULL,
@@ -451,6 +492,19 @@ describe('schema version', () => {
 
       INSERT INTO schema_version (version, applied_at)
       VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10), (11, 11), (12, 12), (13, 13), (14, 14), (15, 15), (16, 16);
+
+      CREATE TABLE role_templates (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        role_type TEXT NOT NULL,
+        description TEXT NOT NULL,
+        default_command TEXT NOT NULL,
+        default_args TEXT NOT NULL,
+        default_env TEXT NOT NULL,
+        is_builtin INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
 
       CREATE TABLE command_presets (
         id TEXT PRIMARY KEY,
@@ -712,6 +766,19 @@ describe('schema version', () => {
       INSERT INTO schema_version (version, applied_at)
       VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10), (11, 11), (12, 12), (13, 13);
 
+      CREATE TABLE role_templates (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        role_type TEXT NOT NULL,
+        description TEXT NOT NULL,
+        default_command TEXT NOT NULL,
+        default_args TEXT NOT NULL,
+        default_env TEXT NOT NULL,
+        is_builtin INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+
       CREATE TABLE messages (
         sequence INTEGER PRIMARY KEY AUTOINCREMENT,
         workspace_id TEXT NOT NULL,
@@ -809,6 +876,19 @@ describe('schema version', () => {
 
       INSERT INTO schema_version (version, applied_at)
       VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10), (11, 11), (12, 12), (13, 13), (14, 14);
+
+      CREATE TABLE role_templates (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        role_type TEXT NOT NULL,
+        description TEXT NOT NULL,
+        default_command TEXT NOT NULL,
+        default_args TEXT NOT NULL,
+        default_env TEXT NOT NULL,
+        is_builtin INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
 
       CREATE TABLE dispatches (
         id TEXT PRIMARY KEY,

--- a/tests/unit/discussion-agent-status.test.ts
+++ b/tests/unit/discussion-agent-status.test.ts
@@ -1,0 +1,207 @@
+import { request as httpRequest } from 'node:http'
+
+import { afterEach, describe, expect, test } from 'vitest'
+
+import type { AgentManager, AgentRunSnapshot } from '../../src/server/agent-manager.js'
+import { createApp } from '../../src/server/app.js'
+import { createRuntimeStore, type RuntimeStore } from '../../src/server/runtime-store.js'
+import { getUiCookie } from '../helpers/ui-session.js'
+
+const outputBus = {
+  clear: () => {},
+  publish: () => {},
+  subscribe: () => () => {},
+}
+
+const createFakeAgentManager = (): AgentManager => {
+  const runs = new Map<string, AgentRunSnapshot>()
+  const onExits = new Map<string, (event: { runId: string; exitCode: number | null }) => void>()
+
+  return {
+    getOutputBus() {
+      return outputBus
+    },
+    pauseRun() {},
+    resizeRun() {},
+    resumeRun() {},
+    getRun(runId) {
+      const run = runs.get(runId)
+      if (!run) throw new Error(`Run not found: ${runId}`)
+      return run
+    },
+    removeRun(runId) {
+      runs.delete(runId)
+    },
+    async startAgent(input) {
+      const run = {
+        agentId: input.agentId,
+        exitCode: null,
+        output: '',
+        pid: 1,
+        runId: `run-${input.agentId}`,
+        status: 'running' as const,
+      }
+      runs.set(run.runId, run)
+      if (input.onExit) onExits.set(run.runId, input.onExit)
+      return run
+    },
+    stopRun(runId) {
+      const run = runs.get(runId)
+      if (!run || run.status === 'exited') return
+      run.status = 'exited'
+      run.exitCode = 0
+      onExits.get(runId)?.({ runId, exitCode: 0 })
+    },
+    writeInput() {},
+  }
+}
+
+const servers: Array<{ close: () => void }> = []
+const stores: RuntimeStore[] = []
+
+afterEach(async () => {
+  while (servers.length > 0) {
+    servers.pop()?.close()
+  }
+  for (const store of stores.splice(0)) await store.close()
+})
+
+const startServer = async () => {
+  const store = createRuntimeStore({ agentManager: createFakeAgentManager() })
+  const app = createApp({ store })
+
+  await new Promise<void>((resolve) => {
+    app.server.listen(0, '127.0.0.1', () => resolve())
+  })
+
+  servers.push(app.server)
+  stores.push(store)
+
+  const address = app.server.address()
+  if (!address || typeof address === 'string') throw new Error('Server did not bind')
+
+  return { baseUrl: `http://127.0.0.1:${address.port}`, store }
+}
+
+const postJson = async (baseUrl: string, path: string, body: unknown, cookie: string) => {
+  const target = new URL(path, baseUrl)
+  const payload = JSON.stringify(body)
+
+  return new Promise<{ body: string; statusCode: number }>((resolve, reject) => {
+    const request = httpRequest(
+      {
+        hostname: target.hostname,
+        path: target.pathname,
+        port: target.port,
+        method: 'POST',
+        headers: {
+          'content-length': Buffer.byteLength(payload).toString(),
+          'content-type': 'application/json',
+          cookie,
+        },
+      },
+      (response) => {
+        let bodyText = ''
+        response.setEncoding('utf8')
+        response.on('data', (chunk) => {
+          bodyText += chunk
+        })
+        response.on('end', () => {
+          resolve({ body: bodyText, statusCode: response.statusCode ?? 0 })
+        })
+      }
+    )
+    request.on('error', reject)
+    request.end(payload)
+  })
+}
+
+describe('discussion participant agent status', () => {
+  test('active discussion members appear working in team list until skip or end', async () => {
+    const { baseUrl, store } = await startServer()
+    const workspace = store.createWorkspace('/tmp/hive-discussion-status', 'Discussion Status')
+    const alice = store.addWorker(workspace.id, { name: 'Alice', role: 'coder' })
+    const bob = store.addWorker(workspace.id, { name: 'Bob', role: 'tester' })
+
+    store.configureAgentLaunch(workspace.id, alice.id, { command: '/bin/bash', args: [] })
+    store.configureAgentLaunch(workspace.id, bob.id, { command: '/bin/bash', args: [] })
+    await store.startAgent(workspace.id, alice.id, { hivePort: '4010' })
+    await store.startAgent(workspace.id, bob.id, { hivePort: '4010' })
+    expect(store.listWorkers(workspace.id).map((w) => [w.name, w.status])).toEqual([
+      ['Alice', 'idle'],
+      ['Bob', 'idle'],
+    ])
+
+    const cookie = await getUiCookie(baseUrl)
+    const startResponse = await postJson(
+      baseUrl,
+      '/api/team/discuss/start',
+      {
+        members: ['Alice', 'Bob'],
+        project_id: workspace.id,
+        topic: 'status test',
+      },
+      cookie
+    )
+    expect(startResponse.statusCode).toBe(201)
+
+    expect(store.listWorkers(workspace.id).map((w) => [w.name, w.status])).toEqual([
+      ['Alice', 'working'],
+      ['Bob', 'working'],
+    ])
+
+    const skipResponse = await postJson(
+      baseUrl,
+      '/api/team/discuss/skip',
+      {
+        project_id: workspace.id,
+        worker_name: 'Alice',
+      },
+      cookie
+    )
+    expect(skipResponse.statusCode).toBe(200)
+
+    expect(store.listWorkers(workspace.id).map((w) => [w.name, w.status])).toEqual([
+      ['Alice', 'idle'],
+      ['Bob', 'idle'],
+    ])
+  })
+
+  test('discussion participant stays working after reporting the last pending dispatch', async () => {
+    const { baseUrl, store } = await startServer()
+    const workspace = store.createWorkspace('/tmp/hive-discussion-report-status', 'Report Status')
+    const alice = store.addWorker(workspace.id, { name: 'Alice', role: 'coder' })
+    const bob = store.addWorker(workspace.id, { name: 'Bob', role: 'tester' })
+
+    store.configureAgentLaunch(workspace.id, alice.id, { command: '/bin/bash', args: [] })
+    store.configureAgentLaunch(workspace.id, bob.id, { command: '/bin/bash', args: [] })
+    await store.startAgent(workspace.id, alice.id, { hivePort: '4010' })
+    await store.startAgent(workspace.id, bob.id, { hivePort: '4010' })
+
+    const cookie = await getUiCookie(baseUrl)
+    const startResponse = await postJson(
+      baseUrl,
+      '/api/team/discuss/start',
+      {
+        members: ['Alice', 'Bob'],
+        project_id: workspace.id,
+        topic: 'report while discussing',
+      },
+      cookie
+    )
+    expect(startResponse.statusCode).toBe(201)
+
+    await store.dispatchTask(workspace.id, alice.id, 'Do a concurrent dispatch')
+    expect(store.getWorker(workspace.id, alice.id)).toMatchObject({
+      pendingTaskCount: 1,
+      status: 'working',
+    })
+
+    store.reportTask(workspace.id, alice.id, { status: 'success', text: 'Done' })
+
+    expect(store.getWorker(workspace.id, alice.id)).toMatchObject({
+      pendingTaskCount: 0,
+      status: 'working',
+    })
+  })
+})

--- a/tests/unit/discussion-operations-sync.test.ts
+++ b/tests/unit/discussion-operations-sync.test.ts
@@ -1,0 +1,106 @@
+import Database from 'better-sqlite3'
+import { beforeEach, describe, expect, test } from 'vitest'
+
+import { createDiscussionOperations } from '../../src/server/discussion-operations.js'
+import { initializeRuntimeDatabase } from '../../src/server/sqlite-schema.js'
+
+describe('discussion sync recovery operations', () => {
+  let db: Database.Database
+  let ops: ReturnType<typeof createDiscussionOperations>
+
+  beforeEach(() => {
+    db = new Database(':memory:')
+    initializeRuntimeDatabase(db)
+    ops = createDiscussionOperations(db)
+  })
+
+  test('lists active discussions for an agent with its member row and messages', () => {
+    const result = ops.startDiscussion({
+      createdBy: 'ws-1:orchestrator',
+      memberAgentIds: ['agent-a', 'agent-b'],
+      topic: 'recover discussion',
+      workspaceId: 'ws-1',
+    })
+
+    ops.submitInitialPosition(result.group.id, 'agent-a', 'Initial A')
+
+    const active = ops.getActiveDiscussionsForAgent('ws-1', 'agent-a')
+
+    expect(active).toHaveLength(1)
+    expect(active[0]!.group.id).toBe(result.group.id)
+    expect(active[0]!.member.agent_id).toBe('agent-a')
+    expect(active[0]!.messages.map((message) => message.text)).toEqual(['Initial A'])
+  })
+
+  test('excludes skipped, failed, and inactive discussion memberships', () => {
+    const skipped = ops.startDiscussion({
+      createdBy: 'ws-1:orchestrator',
+      memberAgentIds: ['agent-a', 'agent-b'],
+      topic: 'skip me',
+      workspaceId: 'ws-1',
+    })
+    ops.skipMember(skipped.group.id, 'agent-a')
+
+    const concluded = ops.startDiscussion({
+      createdBy: 'ws-1:orchestrator',
+      memberAgentIds: ['agent-c', 'agent-d'],
+      topic: 'finish me',
+      workspaceId: 'ws-1',
+    })
+    ops.submitInitialPosition(concluded.group.id, 'agent-c', 'C initial')
+    ops.submitInitialPosition(concluded.group.id, 'agent-d', 'D initial')
+    ops.submitMessage(concluded.group.id, 'agent-c', 'C round')
+    ops.submitMessage(concluded.group.id, 'agent-d', 'D round')
+    ops.submitMessage(concluded.group.id, 'agent-c', 'C round 2')
+    ops.submitMessage(concluded.group.id, 'agent-d', 'D round 2')
+    ops.submitMessage(concluded.group.id, 'agent-c', 'C round 3')
+    ops.submitMessage(concluded.group.id, 'agent-d', 'D round 3')
+    ops.submitConclusion(concluded.group.id, 'agent-c', 'C final')
+    ops.submitConclusion(concluded.group.id, 'agent-d', 'D final')
+
+    expect(ops.getActiveDiscussionsForAgent('ws-1', 'agent-a')).toEqual([])
+    expect(ops.getActiveDiscussionsForAgent('ws-1', 'agent-c')).toEqual([])
+  })
+
+  test('computes phase keys for active and terminal phases', () => {
+    const result = ops.startDiscussion({
+      createdBy: 'ws-1:orchestrator',
+      memberAgentIds: ['agent-a', 'agent-b'],
+      topic: 'phase keys',
+      workspaceId: 'ws-1',
+    })
+
+    expect(ops.getPhaseKey(result.group)).toBe('thinking:0')
+
+    const discussing = ops.submitInitialPosition(result.group.id, 'agent-a', 'A')
+    expect(ops.getPhaseKey(discussing.group)).toBe('thinking:0')
+
+    const transitioned = ops.submitInitialPosition(result.group.id, 'agent-b', 'B')
+    expect(ops.getPhaseKey(transitioned.group)).toBe('discussing:1')
+
+    ops.endDiscussion(result.group.id)
+    expect(ops.getPhaseKey(ops.getGroup(result.group.id))).toBe('terminal')
+  })
+
+  test('injects sync only when the current run has no record for the current phase', () => {
+    const result = ops.startDiscussion({
+      createdBy: 'ws-1:orchestrator',
+      memberAgentIds: ['agent-a', 'agent-b'],
+      topic: 'sync me',
+      workspaceId: 'ws-1',
+    })
+
+    expect(ops.shouldInjectSync(result.group.id, 'agent-a', 'run-1')).toBe(true)
+
+    ops.recordSyncAttempt(result.group.id, 'agent-a', 'thinking:0', 'run-1', 'full_recovery')
+    ops.recordSyncAttempt(result.group.id, 'agent-a', 'thinking:0', 'run-1', 'full_recovery')
+
+    expect(ops.shouldInjectSync(result.group.id, 'agent-a', 'run-1')).toBe(false)
+    expect(ops.shouldInjectSync(result.group.id, 'agent-a', 'run-2')).toBe(true)
+
+    const rows = db
+      .prepare('SELECT * FROM discussion_sync_log WHERE group_id = ? AND member_id = ?')
+      .all(result.group.id, 'agent-a')
+    expect(rows).toHaveLength(1)
+  })
+})

--- a/tests/unit/discussion-post-actions.test.ts
+++ b/tests/unit/discussion-post-actions.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseNextActions } from '../../src/server/discussion-post-actions.js'
+
+describe('parseNextActions', () => {
+  it('should parse "## 4. Next Actions" section (not only ## 5.)', () => {
+    const report = `## 3. Summary
+Some summary here.
+
+## 4. Next Actions
+- Implement the new API endpoint
+- Write integration tests
+- Update documentation
+
+## 5. References
+Some refs.`
+
+    const result = parseNextActions(report)
+    expect(result).toEqual([
+      'Implement the new API endpoint',
+      'Write integration tests',
+      'Update documentation',
+    ])
+  })
+
+  it('should parse "* item" format lists', () => {
+    const report = `## 5. Next Actions
+* Fix the broken test
+* Deploy to staging
+* Notify the team`
+
+    const result = parseNextActions(report)
+    expect(result).toEqual([
+      'Fix the broken test',
+      'Deploy to staging',
+      'Notify the team',
+    ])
+  })
+
+  it('should return empty array for empty report without error', () => {
+    expect(parseNextActions('')).toEqual([])
+  })
+
+  it('should return empty array when no Next Actions section exists', () => {
+    const report = `## 1. Overview
+Just some text.
+
+## 2. Conclusion
+Done.`
+
+    expect(parseNextActions(report)).toEqual([])
+  })
+
+  it('should parse numbered list items (1. item)', () => {
+    const report = `## 3. Next Actions
+1. First action
+2. Second action
+3. Third action
+
+## 4. Notes`
+
+    const result = parseNextActions(report)
+    expect(result).toEqual([
+      'First action',
+      'Second action',
+      'Third action',
+    ])
+  })
+})

--- a/tests/unit/discussion-recovery-injector.test.ts
+++ b/tests/unit/discussion-recovery-injector.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { DiscussionGroup, DiscussionMember, DiscussionMessage } from '../../src/server/discussion-operations.js'
+import {
+  createDiscussionRecoveryInjector,
+  injectDiscussionRecoveryIfNeeded,
+  type DiscussionRecoveryInjectorDeps,
+} from '../../src/server/discussion-recovery-injector.js'
+
+const makeGroup = (overrides: Partial<DiscussionGroup> = {}): DiscussionGroup => ({
+  id: 'group-1',
+  workspace_id: 'ws-1',
+  topic: 'API 设计方案',
+  max_rounds: 3,
+  current_round: 1,
+  max_messages: 30,
+  message_count: 2,
+  status: 'discussing',
+  listen_mode: 'stdin',
+  orch_participates: 0,
+  created_by: 'orch-1',
+  created_at: Date.now(),
+  concluded_at: null,
+  ...overrides,
+})
+
+const makeMember = (overrides: Partial<DiscussionMember> = {}): DiscussionMember => ({
+  group_id: 'group-1',
+  agent_id: 'agent-1',
+  agent_name: '毕昇',
+  role: 'worker',
+  member_status: 'active',
+  initial_position: null,
+  final_position: null,
+  rounds_participated: 0,
+  last_message_at: null,
+  ...overrides,
+})
+
+const makeMessage = (overrides: Partial<DiscussionMessage> = {}): DiscussionMessage => ({
+  sequence: 1,
+  group_id: 'group-1',
+  round: 1,
+  from_agent_id: 'agent-1',
+  message_type: 'discuss',
+  text: '我认为应该用 REST',
+  created_at: Date.now(),
+  ...overrides,
+})
+
+const makeDeps = (overrides: Partial<DiscussionRecoveryInjectorDeps> = {}): DiscussionRecoveryInjectorDeps => ({
+  discussionOps: {
+    getActiveDiscussionsForAgent: vi.fn().mockReturnValue([]),
+    getPhaseKey: vi.fn().mockReturnValue('discussing:1'),
+    shouldInjectSync: vi.fn().mockReturnValue(true),
+    recordSyncAttempt: vi.fn(),
+    getMembers: vi.fn().mockReturnValue([makeMember()]),
+  },
+  writeAgentStdin: vi.fn(),
+  ...overrides,
+})
+
+describe('discussion-recovery-injector', () => {
+  it('does nothing when no active discussions', () => {
+    const deps = makeDeps()
+    injectDiscussionRecoveryIfNeeded('ws-1', 'agent-1', 'run-1', deps)
+
+    expect(deps.writeAgentStdin).not.toHaveBeenCalled()
+    expect(deps.discussionOps.recordSyncAttempt).not.toHaveBeenCalled()
+  })
+
+  it('injects full recovery brief for active member', () => {
+    const group = makeGroup({ status: 'discussing' })
+    const member = makeMember({ member_status: 'active' })
+    const messages = [makeMessage()]
+    const deps = makeDeps({
+      discussionOps: {
+        getActiveDiscussionsForAgent: vi.fn().mockReturnValue([{ group, member, messages }]),
+        getPhaseKey: vi.fn().mockReturnValue('discussing:1'),
+        shouldInjectSync: vi.fn().mockReturnValue(true),
+        recordSyncAttempt: vi.fn(),
+        getMembers: vi.fn().mockReturnValue([member]),
+      },
+    })
+
+    injectDiscussionRecoveryIfNeeded('ws-1', 'agent-1', 'run-1', deps)
+
+    expect(deps.writeAgentStdin).toHaveBeenCalledOnce()
+    const text = (deps.writeAgentStdin as ReturnType<typeof vi.fn>).mock.calls[0]![2] as string
+    expect(text).toContain('讨论恢复上下文')
+    expect(text).toContain('API 设计方案')
+    expect(text).toContain('team discuss --submit')
+    expect(deps.discussionOps.recordSyncAttempt).toHaveBeenCalledWith(
+      'group-1', 'agent-1', 'discussing:1', 'run-1', 'full'
+    )
+  })
+
+  it('injects minimal brief for round_submitted member', () => {
+    const group = makeGroup({ status: 'discussing', current_round: 2 })
+    const member = makeMember({ member_status: 'round_submitted' })
+    const deps = makeDeps({
+      discussionOps: {
+        getActiveDiscussionsForAgent: vi.fn().mockReturnValue([{ group, member, messages: [] }]),
+        getPhaseKey: vi.fn().mockReturnValue('discussing:2'),
+        shouldInjectSync: vi.fn().mockReturnValue(true),
+        recordSyncAttempt: vi.fn(),
+        getMembers: vi.fn().mockReturnValue([member]),
+      },
+    })
+
+    injectDiscussionRecoveryIfNeeded('ws-1', 'agent-1', 'run-1', deps)
+
+    const text = (deps.writeAgentStdin as ReturnType<typeof vi.fn>).mock.calls[0]![2] as string
+    expect(text).toContain('讨论状态变更')
+    expect(deps.discussionOps.recordSyncAttempt).toHaveBeenCalledWith(
+      'group-1', 'agent-1', 'discussing:2', 'run-1', 'minimal'
+    )
+  })
+
+  it('injects terminal notice for concluded discussion', () => {
+    const group = makeGroup({ status: 'concluded' })
+    const member = makeMember({ member_status: 'active' })
+    const deps = makeDeps({
+      discussionOps: {
+        getActiveDiscussionsForAgent: vi.fn().mockReturnValue([{ group, member, messages: [] }]),
+        getPhaseKey: vi.fn().mockReturnValue('terminal'),
+        shouldInjectSync: vi.fn().mockReturnValue(true),
+        recordSyncAttempt: vi.fn(),
+        getMembers: vi.fn().mockReturnValue([member]),
+      },
+    })
+
+    injectDiscussionRecoveryIfNeeded('ws-1', 'agent-1', 'run-1', deps)
+
+    const text = (deps.writeAgentStdin as ReturnType<typeof vi.fn>).mock.calls[0]![2] as string
+    expect(text).toContain('讨论已结束')
+    expect(deps.discussionOps.recordSyncAttempt).toHaveBeenCalledWith(
+      'group-1', 'agent-1', 'terminal', 'run-1', 'terminal'
+    )
+  })
+
+  it('skips injection when shouldInjectSync returns false', () => {
+    const group = makeGroup()
+    const member = makeMember()
+    const deps = makeDeps({
+      discussionOps: {
+        getActiveDiscussionsForAgent: vi.fn().mockReturnValue([{ group, member, messages: [] }]),
+        getPhaseKey: vi.fn().mockReturnValue('discussing:1'),
+        shouldInjectSync: vi.fn().mockReturnValue(false),
+        recordSyncAttempt: vi.fn(),
+        getMembers: vi.fn().mockReturnValue([member]),
+      },
+    })
+
+    injectDiscussionRecoveryIfNeeded('ws-1', 'agent-1', 'run-1', deps)
+
+    expect(deps.writeAgentStdin).not.toHaveBeenCalled()
+    expect(deps.discussionOps.recordSyncAttempt).not.toHaveBeenCalled()
+  })
+
+  it('merges multiple discussions into single stdin write', () => {
+    const group1 = makeGroup({ id: 'group-1', topic: '设计方案 A' })
+    const group2 = makeGroup({ id: 'group-2', topic: '设计方案 B', status: 'thinking' })
+    const member1 = makeMember({ group_id: 'group-1', member_status: 'active' })
+    const member2 = makeMember({ group_id: 'group-2', member_status: 'invited' })
+    const deps = makeDeps({
+      discussionOps: {
+        getActiveDiscussionsForAgent: vi.fn().mockReturnValue([
+          { group: group1, member: member1, messages: [] },
+          { group: group2, member: member2, messages: [] },
+        ]),
+        getPhaseKey: vi.fn().mockImplementation((g: DiscussionGroup) =>
+          g.status === 'thinking' ? 'thinking:0' : 'discussing:1'
+        ),
+        shouldInjectSync: vi.fn().mockReturnValue(true),
+        recordSyncAttempt: vi.fn(),
+        getMembers: vi.fn().mockImplementation((groupId: string) =>
+          groupId === 'group-1' ? [member1] : [member2]
+        ),
+      },
+    })
+
+    injectDiscussionRecoveryIfNeeded('ws-1', 'agent-1', 'run-1', deps)
+
+    expect(deps.writeAgentStdin).toHaveBeenCalledOnce()
+    const text = (deps.writeAgentStdin as ReturnType<typeof vi.fn>).mock.calls[0]![2] as string
+    expect(text).toContain('设计方案 A')
+    expect(text).toContain('设计方案 B')
+    expect(deps.discussionOps.recordSyncAttempt).toHaveBeenCalledTimes(2)
+  })
+
+  it('factory createDiscussionRecoveryInjector works', () => {
+    const group = makeGroup()
+    const member = makeMember({ member_status: 'active' })
+    const deps = makeDeps({
+      discussionOps: {
+        getActiveDiscussionsForAgent: vi.fn().mockReturnValue([{ group, member, messages: [] }]),
+        getPhaseKey: vi.fn().mockReturnValue('discussing:1'),
+        shouldInjectSync: vi.fn().mockReturnValue(true),
+        recordSyncAttempt: vi.fn(),
+        getMembers: vi.fn().mockReturnValue([member]),
+      },
+    })
+
+    const injector = createDiscussionRecoveryInjector(deps)
+    injector.inject('ws-1', 'agent-1', 'run-1')
+
+    expect(deps.writeAgentStdin).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/unit/discussion-recovery-templates.test.ts
+++ b/tests/unit/discussion-recovery-templates.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildFullRecoveryBrief,
+  buildMinimalDeltaBrief,
+  buildTerminalNotice,
+} from '../../src/server/discussion-recovery-templates.js'
+
+describe('discussion-recovery-templates', () => {
+  describe('buildFullRecoveryBrief', () => {
+    it('includes topic, phase, round info', () => {
+      const result = buildFullRecoveryBrief({
+        topic: 'API 设计方案',
+        phase: 'discussing',
+        currentRound: 2,
+        maxRounds: 3,
+        ownSubmissions: [],
+        visibleMessages: [],
+        nextAction: '请用 team discuss --reply 提交你的第 2 轮回应',
+      })
+      expect(result).toContain('API 设计方案')
+      expect(result).toContain('discussing')
+      expect(result).toContain('2/3')
+      expect(result).toContain('请用 team discuss --reply 提交你的第 2 轮回应')
+    })
+
+    it('includes own submissions when present', () => {
+      const result = buildFullRecoveryBrief({
+        topic: '测试讨论',
+        phase: 'thinking',
+        currentRound: 1,
+        maxRounds: 3,
+        ownSubmissions: ['我认为方案 A 更好', '补充：性能考虑'],
+        visibleMessages: [],
+        nextAction: '等待其他成员提交初始观点',
+      })
+      expect(result).toContain('你之前的提交')
+      expect(result).toContain('我认为方案 A 更好')
+      expect(result).toContain('补充：性能考虑')
+    })
+
+    it('includes visible messages when present', () => {
+      const result = buildFullRecoveryBrief({
+        topic: '架构讨论',
+        phase: 'discussing',
+        currentRound: 1,
+        maxRounds: 2,
+        ownSubmissions: [],
+        visibleMessages: [
+          { name: '米芾', text: '建议用事件驱动' },
+          { name: '莫邪', text: '同意，但要考虑顺序' },
+        ],
+        nextAction: '请用 team discuss --reply 提交你的第 1 轮回应',
+      })
+      expect(result).toContain('最近讨论消息')
+      expect(result).toContain('**米芾**: 建议用事件驱动')
+      expect(result).toContain('**莫邪**: 同意，但要考虑顺序')
+    })
+
+    it('ends with the nextAction as final instruction', () => {
+      const result = buildFullRecoveryBrief({
+        topic: 'X',
+        phase: 'concluding',
+        currentRound: 3,
+        maxRounds: 3,
+        ownSubmissions: [],
+        visibleMessages: [],
+        nextAction: '请用 team discuss --final 提交最终结论',
+      })
+      const lines = result.split('\n').filter((l) => l.trim())
+      expect(lines[lines.length - 1]).toBe('请用 team discuss --final 提交最终结论')
+    })
+  })
+
+  describe('buildMinimalDeltaBrief', () => {
+    it('outputs phase change with next action', () => {
+      const result = buildMinimalDeltaBrief({
+        topic: '方案评审',
+        phase: 'concluding',
+        currentRound: 3,
+        nextAction: '请用 team discuss --final 提交最终结论',
+      })
+      expect(result).toContain('方案评审')
+      expect(result).toContain('concluding')
+      expect(result).toContain('轮次 3')
+      expect(result).toContain('请用 team discuss --final 提交最终结论')
+    })
+
+    it('ends with the nextAction', () => {
+      const result = buildMinimalDeltaBrief({
+        topic: 'T',
+        phase: 'discussing',
+        currentRound: 2,
+        nextAction: '请用 team discuss --reply 提交回应',
+      })
+      const lines = result.split('\n').filter((l) => l.trim())
+      expect(lines[lines.length - 1]).toBe('请用 team discuss --reply 提交回应')
+    })
+  })
+
+  describe('buildTerminalNotice', () => {
+    it('handles concluded status', () => {
+      const result = buildTerminalNotice({
+        topic: '设计讨论',
+        finalStatus: 'concluded',
+        synthesisSnippet: '共识：采用方案 B',
+      })
+      expect(result).toContain('结束')
+      expect(result).toContain('达成结论')
+      expect(result).toContain('结论摘要')
+      expect(result).toContain('共识：采用方案 B')
+      expect(result).toContain('你可以继续执行其他任务')
+    })
+
+    it('handles cancelled status', () => {
+      const result = buildTerminalNotice({
+        topic: '风险评审',
+        finalStatus: 'cancelled',
+      })
+      expect(result).toContain('取消')
+      expect(result).toContain('被取消')
+      expect(result).not.toContain('结论摘要')
+      expect(result).toContain('你可以继续执行其他任务')
+    })
+
+    it('omits synthesis section when no snippet', () => {
+      const result = buildTerminalNotice({
+        topic: 'X',
+        finalStatus: 'concluded',
+      })
+      expect(result).not.toContain('结论摘要')
+    })
+  })
+})

--- a/tests/unit/discussion-trigger-evaluate.test.ts
+++ b/tests/unit/discussion-trigger-evaluate.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { type DiscussionTriggerRule, evaluateTrigger } from '../../src/server/discussion-templates.js'
+
+describe('evaluateTrigger', () => {
+  const reviewRule: DiscussionTriggerRule = {
+    condition: 'task_needs_review',
+    description: 'needs review',
+  }
+
+  const riskRule: DiscussionTriggerRule = {
+    condition: 'task_is_high_risk',
+    min_workers: 3,
+    description: 'high risk',
+  }
+
+  it('should NOT match "approve" keyword inside unrelated word "disapprove"', () => {
+    const result = evaluateTrigger('I disapprove of this approach', [reviewRule])
+    expect(result).toEqual([])
+  })
+
+  it('should NOT match "check" inside "error handling completed"', () => {
+    const result = evaluateTrigger('error handling completed', [reviewRule])
+    expect(result).toEqual([])
+  })
+
+  it('should NOT trigger when min_workers requirement is not met', () => {
+    const result = evaluateTrigger('this is a risky production deploy', [riskRule], 2)
+    expect(result).toEqual([])
+  })
+
+  it('should match exact word "approve" when standalone', () => {
+    const result = evaluateTrigger('please approve this change', [reviewRule])
+    expect(result).toHaveLength(1)
+  })
+
+  it('should match exact word "risk" when standalone', () => {
+    const ruleNoMin: DiscussionTriggerRule = {
+      condition: 'task_is_high_risk',
+      description: 'high risk',
+    }
+    const result = evaluateTrigger('this has significant risk', [ruleNoMin])
+    expect(result).toHaveLength(1)
+  })
+})

--- a/web/src/discussion/DiscussionHeader.tsx
+++ b/web/src/discussion/DiscussionHeader.tsx
@@ -1,0 +1,114 @@
+import { MessageCircle, Users } from 'lucide-react'
+import { useMemo } from 'react'
+
+import { useI18n } from '../i18n.js'
+
+import type { DiscussionGroup, DiscussionMessage, DiscussionStatus } from './types.js'
+
+const statusTone: Record<DiscussionStatus, string> = {
+  thinking: 'pill--yellow',
+  discussing: 'pill--blue',
+  concluding: 'pill--purple',
+  concluded: 'pill--green',
+  cancelled: 'pill--red',
+}
+
+const statusDotColor: Record<DiscussionStatus, string> = {
+  thinking: 'bg-yellow-400',
+  discussing: 'bg-blue-400',
+  concluding: 'bg-purple-400',
+  concluded: 'bg-green-400',
+  cancelled: 'bg-red-400',
+}
+
+const MODEL_BADGE_COLORS: Record<string, string> = {
+  claude: 'bg-orange-100 text-orange-700',
+  codex: 'bg-green-100 text-green-700',
+  gemini: 'bg-blue-100 text-blue-700',
+  opencode: 'bg-purple-100 text-purple-700',
+}
+
+type DiscussionHeaderProps = {
+  group: DiscussionGroup
+  messages: DiscussionMessage[]
+  onClose: () => void
+}
+
+export const DiscussionHeader = ({ group, messages, onClose }: DiscussionHeaderProps) => {
+  const { t } = useI18n()
+  const statusLabel = `discussion.status.${group.status}` as const
+
+  const phaseDetail = useMemo(() => {
+    const total = group.members.length
+    if (group.status === 'thinking') {
+      const submitted = group.members.filter((m) => m.initialPosition !== null).length
+      return t('discussion.phase.thinking', { submitted, total })
+    }
+    if (group.status === 'discussing') {
+      const currentRoundMsgs = messages.filter((m) => m.round === group.currentRound)
+      const spoken = new Set(currentRoundMsgs.map((m) => m.fromAgentId)).size
+      return t('discussion.phase.discussing', {
+        round: group.currentRound,
+        maxRounds: group.maxRounds,
+        spoken,
+        total,
+      })
+    }
+    if (group.status === 'concluding') {
+      const submitted = group.members.filter((m) => m.finalPosition !== null).length
+      return t('discussion.phase.concluding', { submitted, total })
+    }
+    return ''
+  }, [group, messages, t])
+
+  return (
+    <div className="flex flex-col gap-2 border-b border-border px-4 py-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <MessageCircle size={16} className="text-ter" />
+          <h3 className="text-sm font-semibold text-pri">{t('discussion.title')}</h3>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-xs text-ter hover:text-pri"
+          aria-label={t('discussion.close')}
+        >
+          &times;
+        </button>
+      </div>
+      <p className="line-clamp-2 text-sm text-sec">{group.topic}</p>
+      <div className="flex items-center gap-3">
+        <span className={`pill ${statusTone[group.status]}`}>{t(statusLabel)}</span>
+        <span className="flex items-center gap-1 text-xs text-ter">
+          <Users size={12} />
+          {group.members.length}
+        </span>
+        <span className="text-xs text-ter">
+          {t('discussion.roundProgress', {
+            current: group.currentRound,
+            total: group.maxRounds,
+          })}
+        </span>
+      </div>
+      {phaseDetail ? (
+        <div className="flex items-center gap-1.5 text-xs text-sec">
+          <span className={`inline-block h-2 w-2 rounded-full ${statusDotColor[group.status]}`} />
+          {phaseDetail}
+        </div>
+      ) : null}
+      <div className="flex flex-wrap items-center gap-1.5">
+        {group.members.map((m) => (
+          <span key={m.agentId} className="flex items-center gap-1 text-xs text-sec">
+            <span>{m.agentName}</span>
+            {m.modelLabel ? (
+              <span className={`rounded px-1 py-0.5 text-[10px] font-medium ${MODEL_BADGE_COLORS[m.modelLabel] ?? 'bg-gray-100 text-gray-600'}`}>
+                {m.modelLabel}
+              </span>
+            ) : null}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/discussion/DiscussionMessage.tsx
+++ b/web/src/discussion/DiscussionMessage.tsx
@@ -1,0 +1,55 @@
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { useState } from 'react'
+
+import { useI18n } from '../i18n.js'
+
+import type { DiscussionMessage as DiscussionMessageType } from './types.js'
+
+const PREVIEW_LINES = 3
+
+const MODEL_BADGE_COLORS: Record<string, string> = {
+  claude: 'bg-orange-100 text-orange-700',
+  codex: 'bg-green-100 text-green-700',
+  gemini: 'bg-blue-100 text-blue-700',
+  opencode: 'bg-purple-100 text-purple-700',
+}
+
+type DiscussionMessageProps = {
+  message: DiscussionMessageType
+}
+
+export const DiscussionMessage = ({ message }: DiscussionMessageProps) => {
+  const { t } = useI18n()
+  const lines = message.text.split('\n')
+  const isLong = lines.length > PREVIEW_LINES
+  const [expanded, setExpanded] = useState(false)
+
+  const displayText = expanded || !isLong ? message.text : lines.slice(0, PREVIEW_LINES).join('\n')
+
+  return (
+    <div className="discussion-message group flex flex-col gap-1 rounded-md px-3 py-2 hover:bg-surface-secondary">
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-medium text-pri">{message.fromAgentName}</span>
+        {message.modelLabel ? (
+          <span className={`rounded px-1 py-0.5 text-[10px] font-medium ${MODEL_BADGE_COLORS[message.modelLabel] ?? 'bg-gray-100 text-gray-600'}`}>
+            {message.modelLabel}
+          </span>
+        ) : null}
+        <span className="text-xs text-ter">
+          {t('discussion.roundLabel', { round: message.round })}
+        </span>
+      </div>
+      <pre className="whitespace-pre-wrap text-sm leading-relaxed text-sec">{displayText}</pre>
+      {isLong ? (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="flex items-center gap-1 text-xs text-link hover:underline"
+        >
+          {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+          {expanded ? t('discussion.collapse') : t('discussion.expand')}
+        </button>
+      ) : null}
+    </div>
+  )
+}

--- a/web/src/discussion/DiscussionPanel.tsx
+++ b/web/src/discussion/DiscussionPanel.tsx
@@ -1,0 +1,384 @@
+import { Compass, FastForward, SkipForward, Square } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { useI18n } from '../i18n.js'
+
+import { DiscussionHeader } from './DiscussionHeader.js'
+import { DiscussionRoundGroup } from './DiscussionRoundGroup.js'
+import { DiscussionTimeline } from './DiscussionTimeline.js'
+import type { TimelineEvent } from './api.js'
+import type { DiscussionGroup, DiscussionMessage } from './types.js'
+
+type DiscussionPanelProps = {
+  group: DiscussionGroup | null
+  messages: DiscussionMessage[]
+  timelineEvents?: TimelineEvent[]
+  onClose: () => void
+  onEndDiscussion?: (cancel: boolean) => void
+  onSteer?: (text: string) => Promise<void>
+  onExtend?: (rounds: number) => Promise<void>
+  onSkipMember?: (agentName: string) => Promise<void>
+}
+
+export const DiscussionPanel = ({
+  group,
+  messages,
+  timelineEvents,
+  onClose,
+  onEndDiscussion,
+  onSteer,
+  onExtend,
+  onSkipMember,
+}: DiscussionPanelProps) => {
+  const { t } = useI18n()
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  const messagesByRound = useMemo(() => {
+    const grouped = new Map<number, DiscussionMessage[]>()
+    for (const msg of messages) {
+      const existing = grouped.get(msg.round)
+      if (existing) {
+        existing.push(msg)
+      } else {
+        grouped.set(msg.round, [msg])
+      }
+    }
+    return grouped
+  }, [messages])
+
+  const submittedAgentIds = useMemo(() => {
+    if (!group) return new Set<string>()
+    const currentRoundMsgs = messagesByRound.get(group.currentRound) ?? []
+    return new Set(currentRoundMsgs.map((m) => m.fromAgentId))
+  }, [group, messagesByRound])
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' })
+  }, [messages.length])
+
+  if (!group) {
+    return (
+      <div className="flex h-full items-center justify-center p-4">
+        <p className="text-sm text-ter">{t('discussion.noActive')}</p>
+      </div>
+    )
+  }
+
+  const isDiscussing = group.status === 'discussing'
+  const isActive = group.status === 'thinking' || group.status === 'discussing'
+  const rounds = Array.from(messagesByRound.keys()).sort((a, b) => a - b)
+
+  return (
+    <div className="flex h-full flex-col">
+      <DiscussionHeader group={group} messages={messages} onClose={onClose} />
+      <div ref={scrollRef} className="flex-1 overflow-y-auto">
+        <div className="flex flex-col gap-3 p-2">
+          {rounds.map((round) => (
+            <DiscussionRoundGroup
+              key={round}
+              round={round}
+              maxRounds={group.maxRounds}
+              messages={messagesByRound.get(round) ?? []}
+              members={group.members}
+              isCurrentRound={round === group.currentRound}
+              submittedAgentIds={submittedAgentIds}
+            />
+          ))}
+        </div>
+      </div>
+      {isDiscussing ? (
+        <InterventionToolbar
+          group={group}
+          submittedAgentIds={submittedAgentIds}
+          onSteer={onSteer}
+          onExtend={onExtend}
+          onSkipMember={onSkipMember}
+          onEnd={onEndDiscussion}
+        />
+      ) : isActive && onEndDiscussion ? (
+        <div className="border-t border-border px-4 py-2">
+          <button
+            type="button"
+            onClick={() => onEndDiscussion(false)}
+            className="btn btn--danger btn--sm w-full"
+          >
+            {t('discussion.endDiscussion')}
+          </button>
+        </div>
+      ) : null}
+      {group.status === 'concluded' ? (
+        <ConcludedTabs messages={messages} group={group} timelineEvents={timelineEvents ?? []} />
+      ) : null}
+    </div>
+  )
+}
+
+// --- Intervention Toolbar ---
+
+type InterventionToolbarProps = {
+  group: DiscussionGroup
+  submittedAgentIds: Set<string>
+  onSteer?: ((text: string) => Promise<void>) | undefined
+  onExtend?: ((rounds: number) => Promise<void>) | undefined
+  onSkipMember?: ((agentName: string) => Promise<void>) | undefined
+  onEnd?: ((cancel: boolean) => void) | undefined
+}
+
+const InterventionToolbar = ({
+  group,
+  submittedAgentIds,
+  onSteer,
+  onExtend,
+  onSkipMember,
+  onEnd,
+}: InterventionToolbarProps) => {
+  const { t } = useI18n()
+  const [steerOpen, setSteerOpen] = useState(false)
+  const [steerText, setSteerText] = useState('')
+  const [extendOpen, setExtendOpen] = useState(false)
+  const [skipOpen, setSkipOpen] = useState(false)
+  const [endOpen, setEndOpen] = useState(false)
+
+  const pendingMembers = group.members.filter((m) => !submittedAgentIds.has(m.agentId))
+
+  const handleSteer = useCallback(async () => {
+    if (!steerText.trim() || !onSteer) return
+    await onSteer(steerText.trim())
+    setSteerText('')
+    setSteerOpen(false)
+  }, [steerText, onSteer])
+
+  return (
+    <div className="border-t border-border px-3 py-2">
+      {steerOpen ? (
+        <div className="flex flex-col gap-2">
+          <input
+            type="text"
+            className="input text-sm"
+            placeholder={t('discussion.toolbar.steerPlaceholder')}
+            value={steerText}
+            onChange={(e) => setSteerText(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleSteer()}
+            autoFocus
+          />
+          <div className="flex gap-2">
+            <button type="button" className="btn btn--primary btn--sm" onClick={handleSteer}>
+              {t('discussion.toolbar.steerConfirm')}
+            </button>
+            <button type="button" className="btn btn--ghost btn--sm" onClick={() => setSteerOpen(false)}>
+              {t('common.cancel')}
+            </button>
+          </div>
+        </div>
+      ) : extendOpen ? (
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-sec">{t('discussion.toolbar.extendLabel')}</span>
+          {[1, 2, 3].map((n) => (
+            <button
+              key={n}
+              type="button"
+              className="btn btn--ghost btn--sm"
+              onClick={() => { onExtend?.(n); setExtendOpen(false) }}
+            >
+              +{n}
+            </button>
+          ))}
+          <button type="button" className="btn btn--ghost btn--sm" onClick={() => setExtendOpen(false)}>
+            {t('common.cancel')}
+          </button>
+        </div>
+      ) : skipOpen ? (
+        <div className="flex flex-col gap-1">
+          <span className="text-xs text-sec">{t('discussion.toolbar.skipLabel')}</span>
+          {pendingMembers.map((m) => (
+            <button
+              key={m.agentId}
+              type="button"
+              className="btn btn--ghost btn--sm text-left"
+              onClick={() => { onSkipMember?.(m.agentName); setSkipOpen(false) }}
+            >
+              {m.agentName}
+            </button>
+          ))}
+          <button type="button" className="btn btn--ghost btn--sm" onClick={() => setSkipOpen(false)}>
+            {t('common.cancel')}
+          </button>
+        </div>
+      ) : endOpen ? (
+        <div className="flex flex-col gap-2">
+          <span className="text-xs text-sec">{t('discussion.toolbar.endConfirm')}</span>
+          <div className="flex gap-2">
+            <button type="button" className="btn btn--primary btn--sm" onClick={() => { onEnd?.(false); setEndOpen(false) }}>
+              {t('discussion.toolbar.endSummarize')}
+            </button>
+            <button type="button" className="btn btn--danger btn--sm" onClick={() => { onEnd?.(true); setEndOpen(false) }}>
+              {t('discussion.toolbar.endCancel')}
+            </button>
+            <button type="button" className="btn btn--ghost btn--sm" onClick={() => setEndOpen(false)}>
+              {t('common.cancel')}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-center gap-1.5">
+          <button type="button" className="btn btn--ghost btn--sm" onClick={() => setSteerOpen(true)} title={t('discussion.toolbar.steer')}>
+            <Compass size={14} />
+          </button>
+          <button type="button" className="btn btn--ghost btn--sm" onClick={() => setExtendOpen(true)} title={t('discussion.toolbar.extend')}>
+            <FastForward size={14} />
+          </button>
+          <button
+            type="button"
+            className="btn btn--ghost btn--sm"
+            onClick={() => setSkipOpen(true)}
+            title={t('discussion.toolbar.skip')}
+            disabled={pendingMembers.length === 0}
+          >
+            <SkipForward size={14} />
+          </button>
+          <div className="ml-auto">
+            <button type="button" className="btn btn--danger btn--sm" onClick={() => setEndOpen(true)} title={t('discussion.toolbar.end')}>
+              <Square size={14} />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// --- Concluded Tabs (Report / Timeline) ---
+
+type ConcludedTabsProps = {
+  messages: DiscussionMessage[]
+  group: DiscussionGroup
+  timelineEvents: TimelineEvent[]
+}
+
+const ConcludedTabs = ({ messages, group, timelineEvents }: ConcludedTabsProps) => {
+  const { t } = useI18n()
+  const [tab, setTab] = useState<'report' | 'timeline'>('report')
+
+  return (
+    <div className="border-t border-border">
+      <div className="flex border-b border-border/50">
+        <button
+          type="button"
+          className={`flex-1 px-3 py-1.5 text-xs font-medium ${tab === 'report' ? 'border-b-2 border-blue-500 text-pri' : 'text-ter hover:text-sec'}`}
+          onClick={() => setTab('report')}
+        >
+          {t('discussion.concluded.tabReport')}
+        </button>
+        <button
+          type="button"
+          className={`flex-1 px-3 py-1.5 text-xs font-medium ${tab === 'timeline' ? 'border-b-2 border-blue-500 text-pri' : 'text-ter hover:text-sec'}`}
+          onClick={() => setTab('timeline')}
+        >
+          {t('discussion.concluded.tabTimeline')}
+        </button>
+      </div>
+      {tab === 'report' ? (
+        <DeltaReport messages={messages} group={group} />
+      ) : (
+        <DiscussionTimeline events={timelineEvents} />
+      )}
+    </div>
+  )
+}
+
+// --- Delta-first Report ---
+
+type DeltaReportProps = {
+  messages: DiscussionMessage[]
+  group: DiscussionGroup
+}
+
+const DELTA_SECTIONS = [
+  'Discussion Delta',
+  'Changed Positions',
+  'Unresolved Disagreements',
+  'Decision-ready Recommendation',
+  'Suggested Next Actions',
+]
+
+const DeltaReport = ({ group }: DeltaReportProps) => {
+  const { t } = useI18n()
+  const [expandedSections, setExpandedSections] = useState<Set<number>>(new Set([0]))
+
+  const sections = useMemo(() => {
+    const result: Array<{ title: string; content: string }> = []
+    const changedMembers = group.members.filter(
+      (m) => m.initialPosition && m.finalPosition && m.initialPosition !== m.finalPosition
+    )
+    const unchangedMembers = group.members.filter(
+      (m) => m.initialPosition && m.finalPosition && m.initialPosition === m.finalPosition
+    )
+
+    result.push({
+      title: DELTA_SECTIONS[0]!,
+      content: changedMembers.length > 0
+        ? changedMembers.map((m) => `${m.agentName}: ${m.finalPosition}`).join('\n')
+        : t('discussion.report.noDelta'),
+    })
+
+    result.push({
+      title: DELTA_SECTIONS[1]!,
+      content: changedMembers.length > 0
+        ? changedMembers.map((m) => `${m.agentName}:\n  Before: ${m.initialPosition}\n  After: ${m.finalPosition}`).join('\n')
+        : t('discussion.report.noChange'),
+    })
+
+    result.push({
+      title: DELTA_SECTIONS[2]!,
+      content: unchangedMembers.length > 1
+        ? unchangedMembers.map((m) => `${m.agentName}: ${m.finalPosition}`).join('\n')
+        : t('discussion.report.noDisagreement'),
+    })
+
+    result.push({
+      title: DELTA_SECTIONS[3]!,
+      content: t('discussion.report.recommendationHint'),
+    })
+
+    result.push({
+      title: DELTA_SECTIONS[4]!,
+      content: t('discussion.report.nextActionsHint'),
+    })
+
+    return result
+  }, [group, t])
+
+  const toggleSection = (idx: number) => {
+    setExpandedSections((prev) => {
+      const next = new Set(prev)
+      if (next.has(idx)) next.delete(idx)
+      else next.add(idx)
+      return next
+    })
+  }
+
+  return (
+    <div className="border-t border-border">
+      <div className="px-4 py-2">
+        <h4 className="text-xs font-semibold text-pri">{t('discussion.report.title')}</h4>
+      </div>
+      {sections.map((section, idx) => (
+        <div key={section.title} className="border-t border-border/50">
+          <button
+            type="button"
+            className="flex w-full items-center justify-between px-4 py-1.5 text-left text-xs font-medium text-sec hover:bg-surface-secondary"
+            onClick={() => toggleSection(idx)}
+          >
+            <span>{idx + 1}. {section.title}</span>
+            <span>{expandedSections.has(idx) ? '−' : '+'}</span>
+          </button>
+          {expandedSections.has(idx) ? (
+            <pre className="whitespace-pre-wrap px-4 pb-2 text-xs leading-relaxed text-ter">
+              {section.content}
+            </pre>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/src/discussion/DiscussionRoundGroup.tsx
+++ b/web/src/discussion/DiscussionRoundGroup.tsx
@@ -1,0 +1,50 @@
+import { useI18n } from '../i18n.js'
+
+import { DiscussionMessage } from './DiscussionMessage.js'
+import { DiscussionTypingIndicator } from './DiscussionTypingIndicator.js'
+import type { DiscussionMessage as DiscussionMessageType, DiscussionMember } from './types.js'
+
+type DiscussionRoundGroupProps = {
+  round: number
+  maxRounds: number
+  messages: DiscussionMessageType[]
+  members: DiscussionMember[]
+  isCurrentRound: boolean
+  submittedAgentIds: Set<string>
+}
+
+export const DiscussionRoundGroup = ({
+  round,
+  maxRounds,
+  messages,
+  members,
+  isCurrentRound,
+  submittedAgentIds,
+}: DiscussionRoundGroupProps) => {
+  const { t } = useI18n()
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="sticky top-0 z-10 flex items-center gap-2 bg-surface-primary px-3 py-1.5">
+        <span className="text-xs font-medium text-ter">
+          {t('discussion.roundProgress', { current: round, total: maxRounds })}
+        </span>
+        {isCurrentRound ? (
+          <span className="pill pill--blue text-[10px]">{t('discussion.current')}</span>
+        ) : null}
+      </div>
+      <div className="flex flex-col gap-0.5">
+        {messages.map((msg) => (
+          <DiscussionMessage key={msg.sequence} message={msg} />
+        ))}
+      </div>
+      {isCurrentRound ? (
+        <DiscussionTypingIndicator
+          members={members}
+          currentRound={round}
+          submittedAgentIds={submittedAgentIds}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/web/src/discussion/DiscussionStartDialog.tsx
+++ b/web/src/discussion/DiscussionStartDialog.tsx
@@ -1,0 +1,228 @@
+import * as Dialog from '@radix-ui/react-dialog'
+import { MessageCircle } from 'lucide-react'
+import { type FormEvent, useState } from 'react'
+
+import type { TeamListItem } from '../../../src/shared/types.js'
+import { useI18n } from '../i18n.js'
+
+import type { StartDiscussionInput } from './api.js'
+
+export interface DiscussionTemplateInfo {
+  id: string
+  defaultRounds: number
+  topicPromptHint: string
+}
+
+const templates: DiscussionTemplateInfo[] = [
+  { id: 'design-review', defaultRounds: 3, topicPromptHint: '' },
+  { id: 'root-cause-debate', defaultRounds: 2, topicPromptHint: '' },
+  { id: 'risk-review', defaultRounds: 2, topicPromptHint: '' },
+  { id: 'compare-approaches', defaultRounds: 3, topicPromptHint: '' },
+]
+
+type DiscussionStartDialogProps = {
+  workers: TeamListItem[]
+  onStart: (input: StartDiscussionInput) => Promise<void>
+  onClose: () => void
+  open: boolean
+  loading?: boolean
+}
+
+export const DiscussionStartDialog = ({
+  workers,
+  onStart,
+  onClose,
+  open,
+  loading = false,
+}: DiscussionStartDialogProps) => {
+  const { t } = useI18n()
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [topic, setTopic] = useState('')
+  const [rounds, setRounds] = useState(3)
+  const [templateId, setTemplateId] = useState<string | null>(null)
+  const [orchParticipates, setOrchParticipates] = useState(false)
+
+  const selectTemplate = (id: string | null) => {
+    setTemplateId(id)
+    if (id) {
+      const tpl = templates.find((t2) => t2.id === id)
+      if (tpl) setRounds(tpl.defaultRounds)
+    }
+  }
+
+  const toggleMember = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    if (selectedIds.size < 2 || !topic.trim()) return
+    await onStart({
+      members: Array.from(selectedIds),
+      topic: topic.trim(),
+      rounds,
+      ...(templateId ? { templateId } : {}),
+      ...(orchParticipates ? { orchParticipates: true } : {}),
+    })
+    setSelectedIds(new Set())
+    setTopic('')
+    setRounds(3)
+    setTemplateId(null)
+    setOrchParticipates(false)
+  }
+
+  const availableWorkers = workers.filter((w) => w.status !== 'stopped')
+  const canSubmit = selectedIds.size >= 2 && topic.trim().length > 0 && !loading
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(v) => !v && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="dialog-overlay" />
+        <Dialog.Content className="dialog-content dialog-content--md" aria-describedby={undefined}>
+          <Dialog.Title className="dialog-title">
+            <MessageCircle size={16} className="mr-2 inline" />
+            {t('discussion.startDialog.title')}
+          </Dialog.Title>
+          <form onSubmit={handleSubmit} className="flex flex-col gap-4 pt-2">
+            <div className="flex flex-col gap-1.5">
+              <label className="text-xs font-medium text-sec">
+                {t('discussion.startDialog.template')}
+              </label>
+              <div className="grid grid-cols-2 gap-2">
+                <button
+                  type="button"
+                  onClick={() => selectTemplate(null)}
+                  className={`rounded border px-3 py-2 text-left text-xs ${
+                    templateId === null
+                      ? 'border-blue-500 bg-blue-500/10'
+                      : 'border-border hover:bg-surface-secondary'
+                  }`}
+                >
+                  <span className="font-medium">{t('discussion.template.none')}</span>
+                </button>
+                {templates.map((tpl) => (
+                  <button
+                    key={tpl.id}
+                    type="button"
+                    onClick={() => selectTemplate(tpl.id)}
+                    className={`rounded border px-3 py-2 text-left text-xs ${
+                      templateId === tpl.id
+                        ? 'border-blue-500 bg-blue-500/10'
+                        : 'border-border hover:bg-surface-secondary'
+                    }`}
+                  >
+                    <span className="font-medium">
+                      {t(`discussion.template.${tpl.id}.name` as 'discussion.template.design-review.name')}
+                    </span>
+                    <p className="mt-0.5 text-ter">
+                      {t(`discussion.template.${tpl.id}.desc` as 'discussion.template.design-review.desc')}
+                    </p>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <label className="text-xs font-medium text-sec">
+                {t('discussion.startDialog.topic')}
+              </label>
+              <textarea
+                className="input min-h-[72px] resize-y"
+                value={topic}
+                onChange={(e) => setTopic(e.target.value)}
+                placeholder={
+                  templateId
+                    ? t(`discussion.template.${templateId}.hint` as 'discussion.template.design-review.hint')
+                    : t('discussion.startDialog.topicPlaceholder')
+                }
+                required
+              />
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <label className="text-xs font-medium text-sec">
+                {t('discussion.startDialog.members')} ({selectedIds.size})
+              </label>
+              <div className="flex max-h-[160px] flex-col gap-1 overflow-y-auto rounded border border-border p-2">
+                {availableWorkers.map((w) => (
+                  <label
+                    key={w.id}
+                    className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 hover:bg-surface-secondary"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.has(w.id)}
+                      onChange={() => toggleMember(w.id)}
+                      className="accent-blue-500"
+                    />
+                    <span className="text-sm text-pri">{w.name}</span>
+                    <span className="text-xs text-ter">({t(`role.${w.role}` as 'role.coder')})</span>
+                  </label>
+                ))}
+                {availableWorkers.length === 0 ? (
+                  <p className="px-2 py-1 text-xs text-ter">
+                    {t('discussion.startDialog.noWorkers')}
+                  </p>
+                ) : null}
+              </div>
+              {selectedIds.size > 0 && selectedIds.size < 2 ? (
+                <p className="text-xs text-orange-500">
+                  {t('discussion.startDialog.minMembers')}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <label className="text-xs font-medium text-sec">
+                {t('discussion.startDialog.rounds')}
+              </label>
+              <input
+                type="number"
+                className="input w-20"
+                min={1}
+                max={10}
+                value={rounds}
+                onChange={(e) => setRounds(Number(e.target.value))}
+              />
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <label className="flex cursor-pointer items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={orchParticipates}
+                  onChange={(e) => setOrchParticipates(e.target.checked)}
+                  className="accent-blue-500"
+                />
+                <span className="text-xs font-medium text-sec">
+                  {t('discussion.startDialog.orchParticipates')}
+                </span>
+              </label>
+              <p className="pl-5 text-xs text-ter">
+                {t('discussion.startDialog.orchParticipatesHint')}
+              </p>
+            </div>
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Dialog.Close asChild>
+                <button type="button" className="btn btn--ghost">
+                  {t('common.cancel')}
+                </button>
+              </Dialog.Close>
+              <button type="submit" className="btn btn--primary" disabled={!canSubmit}>
+                {loading
+                  ? t('discussion.startDialog.starting')
+                  : t('discussion.startDialog.start')}
+              </button>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/web/src/discussion/DiscussionTimeline.tsx
+++ b/web/src/discussion/DiscussionTimeline.tsx
@@ -1,0 +1,84 @@
+import { Clock, MessageCircle, MessageSquare, Settings, Trophy, Zap } from 'lucide-react'
+import { useState } from 'react'
+
+import { useI18n } from '../i18n.js'
+
+import type { TimelineEvent } from './api.js'
+
+type DiscussionTimelineProps = {
+  events: TimelineEvent[]
+}
+
+const EVENT_CONFIG: Record<TimelineEvent['type'], { color: string; icon: typeof Clock }> = {
+  created: { color: 'text-gray-400 border-gray-400/40 bg-gray-400/10', icon: Settings },
+  initial: { color: 'text-yellow-500 border-yellow-500/40 bg-yellow-500/10', icon: Zap },
+  discuss: { color: 'text-blue-500 border-blue-500/40 bg-blue-500/10', icon: MessageCircle },
+  system: { color: 'text-gray-400 border-gray-400/40 bg-gray-400/10', icon: Settings },
+  conclude: { color: 'text-purple-500 border-purple-500/40 bg-purple-500/10', icon: MessageSquare },
+  concluded: { color: 'text-green-500 border-green-500/40 bg-green-500/10', icon: Trophy },
+}
+
+const formatTime = (ts: number) => {
+  const d = new Date(ts)
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}`
+}
+
+export const DiscussionTimeline = ({ events }: DiscussionTimelineProps) => {
+  const { t } = useI18n()
+  const [expandedIdx, setExpandedIdx] = useState<number | null>(null)
+
+  if (events.length === 0) {
+    return <p className="p-4 text-xs text-ter">{t('discussion.timeline.empty')}</p>
+  }
+
+  return (
+    <div className="flex flex-col py-2 pl-4 pr-2">
+      {events.map((event, idx) => {
+        const config = EVENT_CONFIG[event.type]
+        const Icon = config.icon
+        const isExpanded = expandedIdx === idx
+        const summary = event.type === 'created'
+          ? t('discussion.timeline.created')
+          : event.text.length > 80
+            ? `${event.text.slice(0, 80)}…`
+            : event.text
+
+        return (
+          <div key={idx} className="relative flex gap-3 pb-3">
+            {idx < events.length - 1 ? (
+              <div className="absolute left-[11px] top-[24px] bottom-0 w-px bg-border" />
+            ) : null}
+            <div className={`relative z-10 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border ${config.color}`}>
+              <Icon size={12} />
+            </div>
+            <button
+              type="button"
+              className="flex min-w-0 flex-1 flex-col gap-0.5 text-left"
+              onClick={() => setExpandedIdx(isExpanded ? null : idx)}
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-[10px] text-ter">{formatTime(event.timestamp)}</span>
+                {event.agent_name ? (
+                  <span className="text-xs font-medium text-pri">{event.agent_name}</span>
+                ) : null}
+                <span className="text-[10px] text-ter">
+                  {t(`discussion.timeline.type.${event.type}` as 'discussion.timeline.type.created')}
+                </span>
+                {event.round > 0 ? (
+                  <span className="text-[10px] text-ter">R{event.round}</span>
+                ) : null}
+              </div>
+              {isExpanded ? (
+                <pre className="mt-1 max-h-[200px] overflow-auto whitespace-pre-wrap rounded bg-surface-secondary p-2 text-xs leading-relaxed text-sec">
+                  {event.type === 'created' ? JSON.stringify(JSON.parse(event.text), null, 2) : event.text}
+                </pre>
+              ) : (
+                <p className="truncate text-xs text-ter">{summary}</p>
+              )}
+            </button>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/web/src/discussion/DiscussionTypingIndicator.tsx
+++ b/web/src/discussion/DiscussionTypingIndicator.tsx
@@ -1,0 +1,35 @@
+import { useI18n } from '../i18n.js'
+
+import type { DiscussionMember } from './types.js'
+
+type DiscussionTypingIndicatorProps = {
+  members: DiscussionMember[]
+  currentRound: number
+  submittedAgentIds: Set<string>
+}
+
+export const DiscussionTypingIndicator = ({
+  members,
+  currentRound,
+  submittedAgentIds,
+}: DiscussionTypingIndicatorProps) => {
+  const { t } = useI18n()
+  const pending = members.filter((m) => !submittedAgentIds.has(m.agentId))
+
+  if (pending.length === 0) return null
+
+  return (
+    <div className="flex items-center gap-2 px-3 py-2 text-xs text-ter">
+      <span className="typing-dots" aria-hidden>
+        <span className="typing-dot" />
+        <span className="typing-dot" />
+        <span className="typing-dot" />
+      </span>
+      <span>
+        {pending.length === 1
+          ? t('discussion.thinkingSingle', { name: pending[0]!.agentName })
+          : t('discussion.thinkingMultiple', { count: pending.length })}
+      </span>
+    </div>
+  )
+}

--- a/web/src/discussion/api.ts
+++ b/web/src/discussion/api.ts
@@ -1,0 +1,231 @@
+import type { DiscussionGroup, DiscussionMember, DiscussionMessage } from './types.js'
+
+interface DiscussionGroupPayload {
+  id: string
+  workspace_id: string
+  topic: string
+  max_rounds: number
+  current_round: number
+  max_messages: number
+  message_count: number
+  status: DiscussionGroup['status']
+  listen_mode: 'db' | 'stdin'
+  created_by: string
+  created_at: number
+  concluded_at: number | null
+  members: DiscussionMemberPayload[]
+}
+
+interface DiscussionMemberPayload {
+  agent_id: string
+  agent_name: string
+  initial_position: string | null
+  final_position: string | null
+  rounds_participated: number
+  model_label: string | null
+}
+
+interface DiscussionMessagePayload {
+  sequence: number
+  group_id: string
+  round: number
+  from_agent_id: string
+  from_agent_name: string
+  text: string
+  created_at: number
+  model_label: string | null
+}
+
+const fromGroupPayload = (p: DiscussionGroupPayload): DiscussionGroup => ({
+  id: p.id,
+  workspaceId: p.workspace_id,
+  topic: p.topic,
+  maxRounds: p.max_rounds,
+  currentRound: p.current_round,
+  status: p.status,
+  orchListen: p.listen_mode === 'stdin',
+  createdBy: p.created_by,
+  createdAt: p.created_at,
+  concludedAt: p.concluded_at,
+  members: p.members.map(fromMemberPayload),
+})
+
+const fromMemberPayload = (p: DiscussionMemberPayload): DiscussionMember => ({
+  agentId: p.agent_id,
+  agentName: p.agent_name,
+  initialPosition: p.initial_position,
+  finalPosition: p.final_position,
+  roundsParticipated: p.rounds_participated,
+  modelLabel: p.model_label,
+})
+
+const fromMessagePayload = (p: DiscussionMessagePayload): DiscussionMessage => ({
+  sequence: p.sequence,
+  groupId: p.group_id,
+  round: p.round,
+  fromAgentId: p.from_agent_id,
+  fromAgentName: p.from_agent_name ?? p.from_agent_id,
+  text: p.text,
+  createdAt: p.created_at,
+  modelLabel: p.model_label,
+})
+
+const apiFetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const response = await fetch(input, init)
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({})) as { error?: string }
+    throw new Error(body.error ?? `Request failed: ${response.status}`)
+  }
+  return response
+}
+
+const postJson = (url: string, body: Record<string, unknown>): Promise<Response> =>
+  apiFetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+export const getActiveDiscussions = async (workspaceId: string): Promise<DiscussionGroup[]> => {
+  const response = await apiFetch(
+    `/api/team/discuss/active?workspace_id=${encodeURIComponent(workspaceId)}`
+  )
+  const payload = (await response.json()) as DiscussionGroupPayload[]
+  return payload.map(fromGroupPayload)
+}
+
+export const getDiscussionMessages = async (
+  workspaceId: string,
+  groupId: string
+): Promise<DiscussionMessage[]> => {
+  const response = await apiFetch(
+    `/api/team/discuss/messages?workspace_id=${encodeURIComponent(workspaceId)}&group_id=${encodeURIComponent(groupId)}`
+  )
+  const payload = (await response.json()) as DiscussionMessagePayload[]
+  return payload.map(fromMessagePayload)
+}
+
+export interface StartDiscussionInput {
+  members: string[]
+  topic: string
+  rounds?: number
+  listenMode?: 'db' | 'stdin'
+  templateId?: string
+  orchParticipates?: boolean
+}
+
+export const startDiscussion = async (
+  workspaceId: string,
+  input: StartDiscussionInput
+): Promise<{ groupId: string }> => {
+  const response = await postJson('/api/team/discuss/start', {
+    project_id: workspaceId,
+    members: input.members,
+    topic: input.topic,
+    ...(input.rounds ? { rounds: input.rounds } : {}),
+    ...(input.listenMode ? { listen_mode: input.listenMode } : {}),
+    ...(input.templateId ? { template_id: input.templateId } : {}),
+    ...(input.orchParticipates ? { orch_participates: true } : {}),
+  })
+  const data = (await response.json()) as { group_id: string }
+  return { groupId: data.group_id }
+}
+
+export const sendDiscussMessage = async (
+  workspaceId: string,
+  groupId: string,
+  text: string
+): Promise<void> => {
+  await postJson('/api/team/discuss/message', {
+    project_id: workspaceId,
+    group_id: groupId,
+    text,
+  })
+}
+
+export const concludeDiscussion = async (
+  workspaceId: string,
+  groupId: string,
+  finalPosition: string
+): Promise<void> => {
+  await postJson('/api/team/discuss/final', {
+    project_id: workspaceId,
+    group_id: groupId,
+    text: finalPosition,
+  })
+}
+
+export const endDiscussion = async (
+  workspaceId: string,
+  groupId: string,
+  reason?: string,
+  cancel?: boolean
+): Promise<void> => {
+  await postJson('/api/team/discuss/end', {
+    project_id: workspaceId,
+    group_id: groupId,
+    ...(reason ? { reason } : {}),
+    ...(cancel ? { cancel: true } : {}),
+  })
+}
+
+export const skipMember = async (
+  workspaceId: string,
+  groupId: string,
+  workerName: string
+): Promise<void> => {
+  await postJson('/api/team/discuss/skip', {
+    project_id: workspaceId,
+    worker_name: workerName,
+    group_id: groupId,
+  })
+}
+
+export const steerDiscussion = async (
+  workspaceId: string,
+  groupId: string,
+  text: string
+): Promise<void> => {
+  await postJson('/api/team/discuss/steer', {
+    project_id: workspaceId,
+    group_id: groupId,
+    text,
+  })
+}
+
+export const extendRounds = async (
+  workspaceId: string,
+  groupId: string,
+  rounds?: number
+): Promise<void> => {
+  await postJson('/api/team/discuss/extend', {
+    project_id: workspaceId,
+    group_id: groupId,
+    ...(rounds ? { rounds } : {}),
+  })
+}
+
+export interface TimelineEvent {
+  type: 'created' | 'initial' | 'discuss' | 'system' | 'conclude' | 'concluded'
+  timestamp: number
+  agent_id: string | null
+  agent_name: string | null
+  round: number
+  text: string
+}
+
+export interface DiscussionTimelinePayload {
+  group_id: string
+  status: string
+  events: TimelineEvent[]
+}
+
+export const fetchDiscussionTimeline = async (
+  workspaceId: string,
+  groupId: string
+): Promise<DiscussionTimelinePayload> => {
+  const response = await apiFetch(
+    `/api/team/discuss/timeline?workspace_id=${encodeURIComponent(workspaceId)}&group_id=${encodeURIComponent(groupId)}`
+  )
+  return (await response.json()) as DiscussionTimelinePayload
+}

--- a/web/src/discussion/index.ts
+++ b/web/src/discussion/index.ts
@@ -1,0 +1,14 @@
+export { DiscussionHeader } from './DiscussionHeader.js'
+export { DiscussionMessage } from './DiscussionMessage.js'
+export { DiscussionPanel } from './DiscussionPanel.js'
+export { DiscussionRoundGroup } from './DiscussionRoundGroup.js'
+export { DiscussionStartDialog } from './DiscussionStartDialog.js'
+export { DiscussionTypingIndicator } from './DiscussionTypingIndicator.js'
+export { useDiscussion } from './useDiscussion.js'
+export type {
+  DiscussionGroup,
+  DiscussionMember,
+  DiscussionMessage as DiscussionMessageType,
+  DiscussionStateChangeEvent,
+  DiscussionStatus,
+} from './types.js'

--- a/web/src/discussion/types.ts
+++ b/web/src/discussion/types.ts
@@ -1,0 +1,41 @@
+export type DiscussionStatus = 'thinking' | 'discussing' | 'concluding' | 'concluded' | 'cancelled'
+
+export interface DiscussionMember {
+  agentId: string
+  agentName: string
+  initialPosition: string | null
+  finalPosition: string | null
+  roundsParticipated: number
+  modelLabel: string | null
+}
+
+export interface DiscussionGroup {
+  id: string
+  workspaceId: string
+  topic: string
+  maxRounds: number
+  currentRound: number
+  status: DiscussionStatus
+  orchListen: boolean
+  createdBy: string
+  createdAt: number
+  concludedAt: number | null
+  members: DiscussionMember[]
+}
+
+export interface DiscussionMessage {
+  sequence: number
+  groupId: string
+  round: number
+  fromAgentId: string
+  fromAgentName: string
+  text: string
+  createdAt: number
+  modelLabel: string | null
+}
+
+export interface DiscussionStateChangeEvent {
+  groupId: string
+  status: DiscussionStatus
+  currentRound: number
+}

--- a/web/src/discussion/useDiscussion.ts
+++ b/web/src/discussion/useDiscussion.ts
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import {
+  endDiscussion as apiEndDiscussion,
+  fetchDiscussionTimeline,
+  getActiveDiscussions,
+  getDiscussionMessages,
+  startDiscussion as apiStartDiscussion,
+  type StartDiscussionInput,
+  type TimelineEvent,
+} from './api.js'
+import type { DiscussionGroup, DiscussionMessage } from './types.js'
+
+const POLL_INTERVAL_MS = 2000
+
+export interface UseDiscussionResult {
+  activeGroup: DiscussionGroup | null
+  displayGroup: DiscussionGroup | null
+  allGroups: DiscussionGroup[]
+  messages: DiscussionMessage[]
+  timelineEvents: TimelineEvent[]
+  loading: boolean
+  error: string | null
+  startDiscussion: (input: StartDiscussionInput) => Promise<void>
+  endDiscussion: (reason?: string) => Promise<void>
+  refresh: () => void
+}
+
+export const useDiscussion = (workspaceId: string | null): UseDiscussionResult => {
+  const [allGroups, setAllGroups] = useState<DiscussionGroup[]>([])
+  const [messages, setMessages] = useState<DiscussionMessage[]>([])
+  const [timelineEvents, setTimelineEvents] = useState<TimelineEvent[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const mountedRef = useRef(true)
+
+  const fetchState = useCallback(async () => {
+    if (!workspaceId) return
+    try {
+      const groups = await getActiveDiscussions(workspaceId)
+      if (!mountedRef.current) return
+      setAllGroups(groups)
+      setError(null)
+
+      const active = groups.find(
+        (g) => g.status === 'thinking' || g.status === 'discussing' || g.status === 'concluding'
+      )
+      if (active) {
+        const msgs = await getDiscussionMessages(workspaceId, active.id)
+        if (!mountedRef.current) return
+        setMessages(msgs)
+        setTimelineEvents([])
+      } else {
+        const concluded = groups.find((g) => g.status === 'concluded')
+        if (concluded) {
+          const [msgs, timeline] = await Promise.all([
+            getDiscussionMessages(workspaceId, concluded.id),
+            fetchDiscussionTimeline(workspaceId, concluded.id),
+          ])
+          if (!mountedRef.current) return
+          setMessages(msgs)
+          setTimelineEvents(timeline.events)
+        } else {
+          setMessages([])
+          setTimelineEvents([])
+        }
+      }
+    } catch (e) {
+      if (!mountedRef.current) return
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    }
+  }, [workspaceId])
+
+  useEffect(() => {
+    mountedRef.current = true
+    if (!workspaceId) return
+    fetchState()
+    timerRef.current = setInterval(fetchState, POLL_INTERVAL_MS)
+    return () => {
+      mountedRef.current = false
+      if (timerRef.current) clearInterval(timerRef.current)
+    }
+  }, [workspaceId, fetchState])
+
+  const activeGroup =
+    allGroups.find(
+      (g) => g.status === 'thinking' || g.status === 'discussing' || g.status === 'concluding'
+    ) ?? null
+
+  const displayGroup = activeGroup ?? allGroups.find((g) => g.status === 'concluded') ?? null
+
+  const startDiscussion = useCallback(
+    async (input: StartDiscussionInput) => {
+      if (!workspaceId) return
+      setLoading(true)
+      try {
+        await apiStartDiscussion(workspaceId, input)
+        await fetchState()
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to start discussion')
+      } finally {
+        setLoading(false)
+      }
+    },
+    [workspaceId, fetchState]
+  )
+
+  const endDiscussion = useCallback(
+    async (reason?: string) => {
+      if (!workspaceId || !activeGroup) return
+      setLoading(true)
+      try {
+        await apiEndDiscussion(workspaceId, activeGroup.id, reason)
+        await fetchState()
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to end discussion')
+      } finally {
+        setLoading(false)
+      }
+    },
+    [workspaceId, activeGroup, fetchState]
+  )
+
+  return {
+    activeGroup,
+    displayGroup,
+    allGroups,
+    messages,
+    timelineEvents,
+    loading,
+    error,
+    startDiscussion,
+    endDiscussion,
+    refresh: fetchState,
+  }
+}


### PR DESCRIPTION
## Summary
Add multi-round discussion mode allowing agents to participate in structured discussions with crash recovery support.

## Stack Order: 2/6
Depends on PR #9 (DB schema migrations). Merge after #9.

## Changes
- Server: discussion-operations, message-router, recovery-injector, templates
- Routes: routes-discuss.ts
- Web: full discussion UI (DiscussionPanel, Timeline, StartDialog, etc.)
- Tests: unit + integration for discussion recovery
- Spec: docs/specs/2026-05-24-discussion-mode.md