### PR TITLE
[codex] Handle stale terminal input after PTY exit

### DIFF
--- a/src/server/terminal-stream-hub.ts
+++ b/src/server/terminal-stream-hub.ts
@@ -193,7 +193,18 @@ export const createTerminalStreamHub = (store: RuntimeStore): TerminalStreamHub 
         },
       })
       socket.on('message', (raw, isBinary) => {
-        store.writeRunInput(runId, normalizeTerminalInput(raw, isBinary))
+        try {
+          store.writeRunInput(runId, normalizeTerminalInput(raw, isBinary))
+        } catch (error) {
+          if (socket.readyState === socket.OPEN) {
+            socket.send(
+              serializeTerminalError(
+                error instanceof Error ? error.message : 'Terminal input failed'
+              )
+            )
+          }
+          socket.close()
+        }
       })
       socket.on('close', () => {
         if (viewer.ioSocket === socket) viewer.ioSocket = null

--- a/tests/server/terminal-ws.test.ts
+++ b/tests/server/terminal-ws.test.ts
@@ -414,6 +414,49 @@ describe('terminal websocket server', () => {
     }
   })
 
+  test('stale io input after PTY exit does not crash the server', async () => {
+    const workspacePath = join(tmpdir(), `hive-terminal-stale-io-${Date.now()}`)
+    mkdirSync(workspacePath, { recursive: true })
+    tempDirs.push(workspacePath)
+    const script = join(workspacePath, 'exit-fast.js')
+    writeFileSync(script, 'setTimeout(() => process.exit(0), 20)\n')
+
+    const server = await startTestServer()
+    try {
+      const cookie = await getUiCookie(server.baseUrl)
+      const workspace = await createWorkspace(server.baseUrl, cookie, workspacePath)
+      const worker = await createWorker(server.baseUrl, cookie, workspace.id)
+      await configureAgent(server.baseUrl, cookie, workspace.id, worker.id, process.execPath, [
+        script,
+      ])
+      const run = await startAgent(server.baseUrl, cookie, workspace.id, worker.id)
+      const io = await openSocket(toWsUrl(server.baseUrl, `/ws/terminal/${run.runId}/io`), cookie)
+      const messages: string[] = []
+      let closed = false
+
+      io.on('message', (chunk) => {
+        messages.push(chunk.toString())
+      })
+      io.on('close', () => {
+        closed = true
+      })
+
+      await new Promise((resolve) => setTimeout(resolve, 150))
+
+      io.send('late input after exit\n')
+
+      await waitFor(() => {
+        expect(messages.some((message) => message.includes('PTY is not active'))).toBe(true)
+        expect(closed).toBe(true)
+      })
+
+      const health = await fetch(`${server.baseUrl}/api/workspaces`, { headers: { cookie } })
+      expect(health.status).toBe(200)
+    } finally {
+      await server.close()
+    }
+  }, 15000)
+
   test('workspace shell control socket receives an exit event when the shell exits', async () => {
     const workspacePath = join(tmpdir(), `hive-terminal-shell-exit-${Date.now()}`)
     mkdirSync(workspacePath, { recursive: true })


### PR DESCRIPTION
# Fix stale terminal input crash

## What changed
- guard terminal io writes so stale websocket input sent to an exited PTY no longer crashes the whole Hive runtime
- send a terminal error back to the client and close only that broken socket
- add a regression test covering stale io input after PTY exit

## Why
A stale terminal websocket could still send input after the backing PTY had already exited. That bubbled up as `PTY is not active for run: ...` and terminated the runtime process.

## Impact
- Hive stays up instead of crashing when a stale terminal tab sends input to a dead run
- the affected terminal connection gets an error and closes cleanly

## Validation
- `pnpm check`
- `pnpm build`
- attempted a focused websocket regression test locally; the direct runtime fix was validated, but that targeted Vitest case remained timing-sensitive on this Windows environment
