### PR TITLE
Preserve resumed session ids after transient Codex failures

### DIFF
--- a/src/server/agent-manager-support.ts
+++ b/src/server/agent-manager-support.ts
@@ -107,6 +107,7 @@ export const attachAgentPty = (run: AgentRunRecord, pty: IPty, ptyOutputBus: Pty
     },
     pid: pty.pid,
     resize(cols, rows) {
+      if (stopped()) return
       pty.resize(cols, rows)
     },
     resume() {

--- a/tests/unit/agent-manager-finish-run.test.ts
+++ b/tests/unit/agent-manager-finish-run.test.ts
@@ -23,9 +23,11 @@ vi.mock('node-pty', () => ({
   spawn: () => {
     const exitCodes = exitSequences.shift() ?? [0, 0]
     let exitHandler: ((event: { exitCode: number | null }) => void) | undefined
+    let exited = false
 
     queueMicrotask(() => {
       for (const exitCode of exitCodes) {
+        exited = true
         exitHandler?.({ exitCode })
       }
     })
@@ -36,6 +38,9 @@ vi.mock('node-pty', () => ({
       onData() {},
       onExit(handler: (event: { exitCode: number | null }) => void) {
         exitHandler = handler
+      },
+      resize() {
+        if (exited) throw new Error('Cannot resize a pty that has already exited')
       },
       write() {},
     }
@@ -110,5 +115,21 @@ describe('agent manager finishRun', () => {
     expect(onExitSpy).toHaveBeenCalledTimes(1)
     expect(onExitSpy).toHaveBeenCalledWith({ exitCode: null, runId: run.runId })
     expect(manager.getRun(run.runId)).toMatchObject({ exitCode: null, status: 'error' })
+  })
+
+  test('ignores resize requests after the PTY has already exited', async () => {
+    exitSequences.push([1])
+    const manager = createAgentManager()
+    const run = await manager.startAgent({
+      agentId: 'agent-resize-after-exit',
+      command: '/bin/bash',
+      cwd: '/tmp',
+    })
+
+    await waitFor(() => {
+      expect(manager.getRun(run.runId).status).toBe('error')
+    })
+
+    expect(() => manager.resizeRun(run.runId, 120, 40)).not.toThrow()
   })
 })


### PR DESCRIPTION
## Summary

This PR fixes a session recovery edge case where Hive can clear `last_session_id` after a resumed CLI exits non-zero, even when the underlying Codex session still exists.

The original failure was observed with Codex startup/configuration errors, but a later Windows runtime crash showed the same root cause:

- A resumed Codex process exited with `0xC0000409` during image generation under low virtual memory pressure.
- The old `.codex/sessions/**/*.jsonl` file still existed and contained the detailed history.
- Hive started a new bare Codex session afterward and injected a recovery summary, making the previous detailed context appear lost.

The important distinction is that a non-zero resumed process exit is not enough evidence that the persisted session id is stale.

## Changes

- Preserve a resumed session id when the captured session still exists after a non-zero exit.
- Keep the existing recoverable startup/configuration failure handling.
- Keep clearing stale session ids when there is no evidence the old session is still usable.
- Add regression coverage for a Codex resumed run crash where the session JSONL still exists.

## Verification

- `vitest run tests/unit/claude-session-resume-failure.test.ts` passed: 7 tests.
- `biome check` passed for the changed files.

## Notes

The goal is not to hide real stale-session failures. It is to avoid treating transient CLI failures, dependency/configuration errors, or native crashes as proof that the saved session id is invalid.