### PR TITLE
启动配置错误时保留 resumed session id

### DIFF
--- a/src/server/agent-run-exit-handler.ts
+++ b/src/server/agent-run-exit-handler.ts
@@ -20,12 +20,15 @@ export const shouldClearResumedSessionAfterExit = ({
   exitCode,
   output,
   resumedSessionId,
+  sessionStillExists,
 }: {
   exitCode: number | null
   output: string
   resumedSessionId: string | null | undefined
+  sessionStillExists?: boolean
 }) => {
   if (exitCode === 0 || !resumedSessionId) return false
+  if (sessionStillExists) return false
   return !isRecoverableStartupConfigurationFailure(output)
 }
 
@@ -42,15 +45,20 @@ const getRunOutput = (
 }
 
 const clearResumedSessionOnFailure = (
-  context: Pick<AgentRunExitContext, 'agentId' | 'sessionStore' | 'startConfig' | 'workspace'>,
+  context: Pick<
+    AgentRunExitContext,
+    'agentId' | 'sessionExists' | 'sessionStore' | 'startConfig' | 'workspace'
+  >,
   exitCode: number | null,
   output: string
 ) => {
+  const resumedSessionId = context.startConfig.resumedSessionId
   if (
     shouldClearResumedSessionAfterExit({
       exitCode,
       output,
-      resumedSessionId: context.startConfig.resumedSessionId,
+      resumedSessionId,
+      sessionStillExists: resumedSessionId ? context.sessionExists?.(resumedSessionId) : undefined,
     })
   ) {
     context.sessionStore.clearLastSessionId(context.workspace.id, context.agentId)

--- a/src/server/agent-run-exit-handler.ts
+++ b/src/server/agent-run-exit-handler.ts
@@ -1,17 +1,58 @@
 import type { AgentRunExitContext } from './agent-run-start-context.js'
 import { completeLiveRun } from './agent-run-sync.js'
 
+const STARTUP_CONFIGURATION_FAILURE_MARKERS = [
+  'Cannot open external editor',
+  'Missing optional dependency',
+  'failed to parse hooks config',
+]
+
 interface HandleRunExitInput {
   exitCode: number | null
   endedAt: number
   runId: string
 }
 
+export const isRecoverableStartupConfigurationFailure = (output: string) =>
+  STARTUP_CONFIGURATION_FAILURE_MARKERS.some((marker) => output.includes(marker))
+
+export const shouldClearResumedSessionAfterExit = ({
+  exitCode,
+  output,
+  resumedSessionId,
+}: {
+  exitCode: number | null
+  output: string
+  resumedSessionId: string | null | undefined
+}) => {
+  if (exitCode === 0 || !resumedSessionId) return false
+  return !isRecoverableStartupConfigurationFailure(output)
+}
+
+const getRunOutput = (
+  context: Pick<AgentRunExitContext, 'getRunOutput'>,
+  runId: string,
+  fallbackOutput: string
+) => {
+  try {
+    return context.getRunOutput?.(runId) ?? fallbackOutput
+  } catch {
+    return fallbackOutput
+  }
+}
+
 const clearResumedSessionOnFailure = (
   context: Pick<AgentRunExitContext, 'agentId' | 'sessionStore' | 'startConfig' | 'workspace'>,
-  exitCode: number | null
+  exitCode: number | null,
+  output: string
 ) => {
-  if (exitCode !== 0 && context.startConfig.resumedSessionId) {
+  if (
+    shouldClearResumedSessionAfterExit({
+      exitCode,
+      output,
+      resumedSessionId: context.startConfig.resumedSessionId,
+    })
+  ) {
     context.sessionStore.clearLastSessionId(context.workspace.id, context.agentId)
   }
 }
@@ -32,7 +73,8 @@ export const handleAgentRunExit = (
   }
 
   completeLiveRun(liveRun, exitCode, endedAt, context.store)
-  clearResumedSessionOnFailure(context, exitCode)
+  const output = getRunOutput(context, runId, liveRun.output)
+  clearResumedSessionOnFailure(context, exitCode, output)
   context.handledRunExits.add(runId)
   context.tokenRegistry.revokeIfMatches(context.agentId, context.token)
   context.onAgentExit(context.workspace.id, context.agentId)

--- a/src/server/agent-run-start-context.ts
+++ b/src/server/agent-run-start-context.ts
@@ -30,6 +30,7 @@ export interface AgentRunExitContext {
   handledRunExits: Set<string>
   onAgentExit: (workspaceId: string, agentId: string) => void
   registry: LiveRunRegistry
+  sessionExists?: (sessionId: string) => boolean
   sessionStore: AgentSessionStorePort
   startConfig: { resumedSessionId?: string | null }
   store: AgentRunStarterStorePort

--- a/src/server/agent-run-start-context.ts
+++ b/src/server/agent-run-start-context.ts
@@ -26,6 +26,7 @@ export interface AgentRunStarterStorePort {
 
 export interface AgentRunExitContext {
   agentId: string
+  getRunOutput?: (runId: string) => string
   handledRunExits: Set<string>
   onAgentExit: (workspaceId: string, agentId: string) => void
   registry: LiveRunRegistry

--- a/src/server/agent-run-starter.ts
+++ b/src/server/agent-run-starter.ts
@@ -12,6 +12,7 @@ import type { CommandPresetRecord } from './command-preset-store.js'
 import type { LiveRunRegistry } from './live-run-registry.js'
 import { createPostStartInputWriter, isInteractiveAgentCommand } from './post-start-input-writer.js'
 import type { RestartPolicy } from './restart-policy.js'
+import { doesCapturedSessionExist } from './session-capture.js'
 
 interface AgentRunStarterInput {
   agentManager: AgentManager | undefined
@@ -64,6 +65,11 @@ export const createAgentRunStarter =
       handledRunExits,
       onAgentExit,
       registry,
+      sessionExists: (sessionId) =>
+        Boolean(
+          startConfig.sessionIdCapture &&
+            doesCapturedSessionExist(workspace.path, startConfig.sessionIdCapture, sessionId)
+        ),
       sessionStore,
       startConfig,
       store,
@@ -131,6 +137,14 @@ export const createAgentRunStarter =
           exitCode: run.exitCode,
           output: run.output,
           resumedSessionId: startConfig.resumedSessionId,
+          sessionStillExists:
+            startConfig.resumedSessionId && startConfig.sessionIdCapture
+              ? doesCapturedSessionExist(
+                  workspace.path,
+                  startConfig.sessionIdCapture,
+                  startConfig.resumedSessionId
+                )
+              : undefined,
         })
       ) {
         sessionStore.clearLastSessionId(workspace.id, agentId)

--- a/src/server/agent-run-starter.ts
+++ b/src/server/agent-run-starter.ts
@@ -1,7 +1,7 @@
 import type { AgentSummary, WorkspaceSummary } from '../shared/types.js'
 import type { AgentManager } from './agent-manager.js'
 import { buildAgentRunBootstrap, startAgentRunCapture } from './agent-run-bootstrap.js'
-import { handleAgentRunExit } from './agent-run-exit-handler.js'
+import { handleAgentRunExit, shouldClearResumedSessionAfterExit } from './agent-run-exit-handler.js'
 import type { AgentRunExitContext, AgentRunStarterStorePort } from './agent-run-start-context.js'
 import type { AgentLaunchConfigInput } from './agent-run-store.js'
 import type { AgentSessionStorePort } from './agent-runtime-ports.js'
@@ -60,6 +60,7 @@ export const createAgentRunStarter =
     const token = tokenRegistry.issue(agentId)
     const exitContext: AgentRunExitContext = {
       agentId,
+      getRunOutput: (runId) => agentManager.getRun(runId).output,
       handledRunExits,
       onAgentExit,
       registry,
@@ -125,7 +126,13 @@ export const createAgentRunStarter =
 
     if (run.status === 'error') {
       store.updatePersistedRun(run.runId, 'error', run.exitCode, Date.now())
-      if (startConfig.resumedSessionId) {
+      if (
+        shouldClearResumedSessionAfterExit({
+          exitCode: run.exitCode,
+          output: run.output,
+          resumedSessionId: startConfig.resumedSessionId,
+        })
+      ) {
         sessionStore.clearLastSessionId(workspace.id, agentId)
       }
       tokenRegistry.revokeIfMatches(agentId, token)

--- a/tests/unit/claude-session-resume-failure.test.ts
+++ b/tests/unit/claude-session-resume-failure.test.ts
@@ -27,8 +27,29 @@ const createClaudeSessionRoot = (cwd: string, sessionId: string) => {
   process.env.HIVE_CLAUDE_PROJECTS_DIR = root
 }
 
+const createCodexSessionRoot = (cwd: string, sessionId: string) => {
+  const root = join(tmpdir(), `hive-codex-session-${crypto.randomUUID()}`)
+  const sessionDir = join(root, 'sessions', '2026', '07', '03')
+  mkdirSync(sessionDir, { recursive: true })
+  writeFileSync(
+    join(sessionDir, `rollout-2026-07-03T09-59-05-${sessionId}.jsonl`),
+    `${JSON.stringify({
+      payload: {
+        cwd,
+        id: sessionId,
+        session_id: sessionId,
+      },
+      timestamp: '2026-07-03T01:59:17.305Z',
+      type: 'session_meta',
+    })}\n`
+  )
+  tempDirs.push(root)
+  process.env.CODEX_HOME = root
+}
+
 afterEach(() => {
   delete process.env.HIVE_CLAUDE_PROJECTS_DIR
+  delete process.env.CODEX_HOME
   for (const dir of tempDirs.splice(0)) rmSync(dir, { force: true, recursive: true })
   vi.restoreAllMocks()
 })
@@ -44,6 +65,17 @@ describe('claude session resume failure', () => {
         exitCode: 1,
         output,
         resumedSessionId: '77777777-7777-4777-8777-777777777777',
+      })
+    ).toBe(false)
+  })
+
+  test('preserves resumed session id when the captured session still exists after a crash', () => {
+    expect(
+      shouldClearResumedSessionAfterExit({
+        exitCode: -1073740791,
+        output: '',
+        resumedSessionId: '77777777-7777-4777-8777-777777777777',
+        sessionStillExists: true,
       })
     ).toBe(false)
   })
@@ -144,6 +176,95 @@ describe('claude session resume failure', () => {
     ).toEqual({ last_session_id: null })
 
     db.close()
+  })
+
+  test('keeps session id when resumed Codex run crashes but its session file still exists', async () => {
+    const cwd = '/tmp/hive-codex-runtime-crash-workspace'
+    const sessionId = '99999999-9999-4999-8999-999999999999'
+    createCodexSessionRoot(cwd, sessionId)
+    let lastSessionId: string | undefined = sessionId
+    const clearLastSessionId = vi.fn(() => {
+      lastSessionId = undefined
+    })
+    const sessionStore = {
+      clearLastSessionId,
+      getLastSessionId: () => lastSessionId,
+      setLastSessionId: (_workspaceId: string, _agentId: string, nextSessionId: string) => {
+        lastSessionId = nextSessionId
+      },
+    }
+    let runIndex = 0
+    const startArgs: Array<string[] | undefined> = []
+    const runtime = createAgentRuntime(
+      {
+        getRun: (runId) => ({
+          agentId: 'agent-1',
+          exitCode: runId === 'run-1' ? -1073740791 : null,
+          output: '',
+          pid: 1,
+          runId,
+          status: runId === 'run-1' ? 'error' : 'running',
+        }),
+        startAgent: async (input) => {
+          runIndex += 1
+          const runId = `run-${runIndex}`
+          startArgs.push(input.args)
+          if (runId === 'run-1') {
+            input.onExit?.({ runId, exitCode: -1073740791 })
+          }
+          return {
+            agentId: 'agent-1',
+            exitCode: runId === 'run-1' ? -1073740791 : null,
+            output: '',
+            pid: 1,
+            runId,
+            status: 'starting',
+          }
+        },
+        getOutputBus: () => outputBus,
+        pauseRun: () => {},
+        removeRun: () => {},
+        resizeRun: () => {},
+        resumeRun: () => {},
+        stopRun: () => {},
+        writeInput: () => {},
+      },
+      {
+        insertAgentRun: () => {},
+        listAgentRuns: () => [],
+        listLaunchConfigs: () => [
+          {
+            workspaceId: 'ws-1',
+            agentId: 'agent-1',
+            config: {
+              command: 'codex',
+              args: [],
+              resumeArgsTemplate: 'resume {session_id}',
+              sessionIdCapture: {
+                pattern: '~/.codex/sessions/**/*.jsonl',
+                source: 'codex_session_jsonl_dir',
+              },
+            },
+          },
+        ],
+        deleteLaunchConfig: () => {},
+        markUnfinishedRunsStale: () => {},
+        saveLaunchConfig: () => {},
+        updatePersistedRun: () => {},
+      },
+      sessionStore,
+      () => undefined,
+      () => {}
+    )
+
+    await runtime.startAgent({ id: 'ws-1', name: 'A', path: cwd }, 'agent-1', { hivePort: '4010' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await runtime.startAgent({ id: 'ws-1', name: 'A', path: cwd }, 'agent-1', { hivePort: '4010' })
+
+    expect(startArgs[0]).toEqual(['resume', sessionId])
+    expect(startArgs[1]).toEqual(['resume', sessionId])
+    expect(clearLastSessionId).not.toHaveBeenCalled()
+    expect(lastSessionId).toBe(sessionId)
   })
 
   test('keeps session id when resumed run exits with Codex startup configuration error', async () => {

--- a/tests/unit/claude-session-resume-failure.test.ts
+++ b/tests/unit/claude-session-resume-failure.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 
 import Database from 'better-sqlite3'
 import { afterEach, describe, expect, test, vi } from 'vitest'
+import { shouldClearResumedSessionAfterExit } from '../../src/server/agent-run-exit-handler.js'
 import { createAgentRuntime } from '../../src/server/agent-runtime.js'
 import { createAgentSessionStore } from '../../src/server/agent-session-store.js'
 import { encodeClaudeProjectPath } from '../../src/server/session-capture-claude.js'
@@ -33,6 +34,20 @@ afterEach(() => {
 })
 
 describe('claude session resume failure', () => {
+  test.each([
+    'Error: Missing optional dependency @openai/codex-win32-x64',
+    'Cannot open external editor: set $VISUAL or $EDITOR before starting Codex.',
+    'failed to parse hooks config C:\\Users\\alice\\.codex\\hooks.json: unknown field `SessionStart`',
+  ])('preserves resumed session id for recoverable startup configuration failure', (output) => {
+    expect(
+      shouldClearResumedSessionAfterExit({
+        exitCode: 1,
+        output,
+        resumedSessionId: '77777777-7777-4777-8777-777777777777',
+      })
+    ).toBe(false)
+  })
+
   test('clears stale session id after resumed Claude run exits non-zero and next start is bare', async () => {
     const cwd = '/tmp/hive-resume-failure-workspace'
     const staleSessionId = '77777777-7777-4777-8777-777777777777'
@@ -129,5 +144,91 @@ describe('claude session resume failure', () => {
     ).toEqual({ last_session_id: null })
 
     db.close()
+  })
+
+  test('keeps session id when resumed run exits with Codex startup configuration error', async () => {
+    const cwd = '/tmp/hive-codex-startup-failure-workspace'
+    const sessionId = '88888888-8888-4888-8888-888888888888'
+    const startupError = 'Error: Missing optional dependency @openai/codex-win32-x64'
+    let lastSessionId: string | undefined = sessionId
+    const clearLastSessionId = vi.fn(() => {
+      lastSessionId = undefined
+    })
+    const sessionStore = {
+      clearLastSessionId,
+      getLastSessionId: () => lastSessionId,
+      setLastSessionId: (_workspaceId: string, _agentId: string, nextSessionId: string) => {
+        lastSessionId = nextSessionId
+      },
+    }
+    let runIndex = 0
+    const startArgs: Array<string[] | undefined> = []
+    const runtime = createAgentRuntime(
+      {
+        getRun: (runId) => ({
+          agentId: 'agent-1',
+          exitCode: runId === 'run-1' ? 1 : null,
+          output: runId === 'run-1' ? startupError : '',
+          pid: 1,
+          runId,
+          status: runId === 'run-1' ? 'error' : 'running',
+        }),
+        startAgent: async (input) => {
+          runIndex += 1
+          const runId = `run-${runIndex}`
+          startArgs.push(input.args)
+          if (runId === 'run-1') {
+            input.onExit?.({ runId, exitCode: 1 })
+          }
+          return {
+            agentId: 'agent-1',
+            exitCode: runId === 'run-1' ? 1 : null,
+            output: runId === 'run-1' ? startupError : '',
+            pid: 1,
+            runId,
+            status: runId === 'run-1' ? 'starting' : 'starting',
+          }
+        },
+        getOutputBus: () => outputBus,
+        pauseRun: () => {},
+        removeRun: () => {},
+        resizeRun: () => {},
+        resumeRun: () => {},
+        stopRun: () => {},
+        writeInput: () => {},
+      },
+      {
+        insertAgentRun: () => {},
+        listAgentRuns: () => [],
+        listLaunchConfigs: () => [
+          {
+            workspaceId: 'ws-1',
+            agentId: 'agent-1',
+            config: {
+              command: 'codex',
+              args: [],
+              resumeArgsTemplate: '--resume {session_id}',
+              sessionIdCapture: null,
+            },
+          },
+        ],
+        deleteLaunchConfig: () => {},
+        markUnfinishedRunsStale: () => {},
+        saveLaunchConfig: () => {},
+        updatePersistedRun: () => {},
+      },
+      sessionStore,
+      () => undefined,
+      () => {}
+    )
+
+    await runtime.startAgent({ id: 'ws-1', name: 'A', path: cwd }, 'agent-1', { hivePort: '4010' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await runtime.startAgent({ id: 'ws-1', name: 'A', path: cwd }, 'agent-1', { hivePort: '4010' })
+
+    expect(startArgs[0]).toEqual(['--resume', sessionId])
+    expect(startArgs[1]).toEqual(['--resume', sessionId])
+    expect(clearLastSessionId).not.toHaveBeenCalled()
+    expect(lastSessionId).toBe(sessionId)
   })
 })


### PR DESCRIPTION
## 摘要

- 增加统一判断函数，决定 resumed run 非零退出后是否应该清理持久化 session id。
- 对可恢复的本地启动/配置错误保留 session id，例如 Codex optional dependency 缺失、hooks 配置格式错误、缺少 `$VISUAL` / `$EDITOR`。
- 在 exit handler 中从 `AgentManager` 读取最新 run output，再决定是否清理 `last_session_id`。
- 保留原有的 generic 非零退出清理行为，因此真正 stale/bad resume 失败时仍会清掉 session id。

## 背景

Hive 当前把任意 resumed run 的非零退出都当作保存的 session id 已损坏。

但 Codex 可能在还没进入交互提示符之前，就因为本地安装或配置问题退出，例如：

- `Missing optional dependency @openai/codex-win32-x64`
- `Cannot open external editor`
- `failed to parse hooks config`

这些错误不代表之前的 session id 无效。此时清掉 `last_session_id`，会导致下一次启动不再带 `--resume`，用户看到的结果就像会话上下文丢了，尽管原始 Codex session 文件仍然存在。

## 复现 Demo

```js
// fake-codex-startup-failure.mjs
console.error('Error: Missing optional dependency @openai/codex-win32-x64')
process.exit(1)
```

配置 worker：

```json
{
  "command": "node",
  "args": ["C:/tmp/fake-codex-startup-failure.mjs"],
  "resumeArgsTemplate": "--resume {session_id}",
  "sessionIdCapture": null
}
```

先写入 `agent_sessions.last_session_id`，然后启动 worker。

修复前：fake command 退出后，Hive 会清掉保存的 session id。  
修复后：Hive 会保留 session id，下一次启动仍然传入 `--resume <session_id>`。

## 测试

- `volta run --node 22 --pnpm 10.30.3 pnpm exec tsc -p tsconfig.build.json --noEmit`
- `volta run --node 22 --pnpm 10.30.3 pnpm exec biome check src/server/agent-run-start-context.ts src/server/agent-run-exit-handler.ts src/server/agent-run-starter.ts tests/unit/claude-session-resume-failure.test.ts`
- `volta run --node 22 --pnpm 10.30.3 pnpm exec vitest run tests/unit/claude-session-resume-failure.test.ts --no-file-parallelism --maxWorkers=1`





关联 Issue：#39